### PR TITLE
Ignore required parameter count errors with `expectError`

### DIFF
--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -20,7 +20,9 @@ const diagnosticCodesToIgnore = new Set<DiagnosticCode>([
 	DiagnosticCode.ArgumentTypeIsNotAssignableToParameterType,
 	DiagnosticCode.PropertyDoesNotExistOnType,
 	DiagnosticCode.CannotAssignToReadOnlyProperty,
-	DiagnosticCode.TypeIsNotAssignableToOtherType
+	DiagnosticCode.TypeIsNotAssignableToOtherType,
+	DiagnosticCode.GenericTypeRequiresTypeArguments,
+	DiagnosticCode.ExpectedArgumentsButGotOther
 ]);
 
 /**

--- a/source/lib/interfaces.ts
+++ b/source/lib/interfaces.ts
@@ -21,10 +21,12 @@ export interface Context {
 
 export enum DiagnosticCode {
 	AwaitIsOnlyAllowedInAsyncFunction = 1308,
+	GenericTypeRequiresTypeArguments = 2314,
 	TypeIsNotAssignableToOtherType = 2322,
 	PropertyDoesNotExistOnType = 2339,
 	ArgumentTypeIsNotAssignableToParameterType = 2345,
-	CannotAssignToReadOnlyProperty = 2540
+	CannotAssignToReadOnlyProperty = 2540,
+	ExpectedArgumentsButGotOther = 2554
 }
 
 export interface Diagnostic {

--- a/source/test/fixtures/expect-error/values/index.d.ts
+++ b/source/test/fixtures/expect-error/values/index.d.ts
@@ -8,3 +8,5 @@ export default one;
 export const foo: {readonly bar: string};
 
 export function hasProperty(property: {name: string}): boolean;
+
+export interface Options<T> {}

--- a/source/test/fixtures/expect-error/values/index.test-d.ts
+++ b/source/test/fixtures/expect-error/values/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectError} from '../../../..';
-import {foo, hasProperty} from '.';
+import {default as one, foo, hasProperty, Options} from '.';
 
 expectError<string>(1);
 expectError<string>('fo');
@@ -16,3 +16,7 @@ try {
 } catch {}
 
 expectError(hasProperty({name: 1}));
+
+expectError(one(1));
+expectError(one(1, 2, 3));
+expectError({} as Options);


### PR DESCRIPTION
Fixes #25.