### PR TITLE
Ignore no overload matches error in expectError assertion

### DIFF
--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -22,7 +22,8 @@ const diagnosticCodesToIgnore = new Set<DiagnosticCode>([
 	DiagnosticCode.CannotAssignToReadOnlyProperty,
 	DiagnosticCode.TypeIsNotAssignableToOtherType,
 	DiagnosticCode.GenericTypeRequiresTypeArguments,
-	DiagnosticCode.ExpectedArgumentsButGotOther
+	DiagnosticCode.ExpectedArgumentsButGotOther,
+	DiagnosticCode.NoOverloadMatches
 ]);
 
 /**

--- a/source/lib/interfaces.ts
+++ b/source/lib/interfaces.ts
@@ -26,7 +26,8 @@ export enum DiagnosticCode {
 	PropertyDoesNotExistOnType = 2339,
 	ArgumentTypeIsNotAssignableToParameterType = 2345,
 	CannotAssignToReadOnlyProperty = 2540,
-	ExpectedArgumentsButGotOther = 2554
+	ExpectedArgumentsButGotOther = 2554,
+	NoOverloadMatches = 2769
 }
 
 export interface Diagnostic {

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -189,7 +189,7 @@ test('support setting a custom test directory', async t => {
 test('expectError for functions', async t => {
 	const diagnostics = await m({cwd: path.join(__dirname, 'fixtures/expect-error/functions')});
 
-	t.true(diagnostics.length === 1);
+	t.true(diagnostics.length === 1, `Diagnostics: ${diagnostics.map(d => d.message)}`);
 
 	t.true(diagnostics[0].column === 0);
 	t.true(diagnostics[0].line === 5);


### PR DESCRIPTION
👋  It looks like TS 3.6 has a new error code which isn't classed as being ignorable in a test, this adds that. As well as providing a bit of error info when that first diagnostics. test fails. 

I'm fine with ditching the extra info on the assertion.