### PR TITLE
Add a way to validate the memory usage of your dts files

### DIFF
--- a/source/cli.ts
+++ b/source/cli.ts
@@ -8,6 +8,11 @@ const cli = meow(`
 	Usage
 		$ tsd [path]
 
+	Options
+		--verify-size, -s  Keep on top of the memory usage with a data snapshot
+		--write, -w        Overwrite existing memory usage JSON fixture
+		--size-delta, -d   What percent of change is allow in memory usage, default is 10
+
 	Examples
 	  $ tsd /path/to/project
 
@@ -15,13 +20,37 @@ const cli = meow(`
 
 	    index.test-d.ts
 	    ✖  10:20  Argument of type string is not assignable to parameter of type number.
-`);
+`,
+	{
+		flags: {
+			verifySize: {
+				type: 'boolean',
+				alias: 'u'
+			},
+			write: {
+				type: 'boolean',
+				alias: 'w'
+			},
+			sizeDelta: {
+				type: 'string',
+				alias: 'd',
+				default: '10'
+			}
+		}
+	}
+);
 
 (async () => {	// tslint:disable-line:no-floating-promises
 	updateNotifier({pkg: cli.pkg}).notify();
 
 	try {
-		const options = cli.input.length > 0 ? {cwd: cli.input[0]} : undefined;
+		const cwd = cli.input.length > 0 ? cli.input[0] : process.cwd();
+		const options = {
+			cwd,
+			verify: cli.flags.verifySize,
+			writeSnapshot: cli.flags.write,
+			sizeDelta: parseInt(cli.flags.sizeDelta, 10)
+		};
 
 		const diagnostics = await tsd(options);
 

--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -22,7 +22,8 @@ const diagnosticCodesToIgnore = new Set<DiagnosticCode>([
 	DiagnosticCode.CannotAssignToReadOnlyProperty,
 	DiagnosticCode.TypeIsNotAssignableToOtherType,
 	DiagnosticCode.GenericTypeRequiresTypeArguments,
-	DiagnosticCode.ExpectedArgumentsButGotOther
+	DiagnosticCode.ExpectedArgumentsButGotOther,
+	DiagnosticCode.NoOverloadMatches
 ]);
 
 /**

--- a/source/lib/interfaces.ts
+++ b/source/lib/interfaces.ts
@@ -26,7 +26,8 @@ export enum DiagnosticCode {
 	PropertyDoesNotExistOnType = 2339,
 	ArgumentTypeIsNotAssignableToParameterType = 2345,
 	CannotAssignToReadOnlyProperty = 2540,
-	ExpectedArgumentsButGotOther = 2554
+	ExpectedArgumentsButGotOther = 2554,
+	NoOverloadMatches = 2769
 }
 
 export interface Diagnostic {

--- a/source/lib/interfaces.ts
+++ b/source/lib/interfaces.ts
@@ -12,11 +12,18 @@ export interface Config<Options = CompilerOptions> {
 export type RawConfig = Partial<Config<RawCompilerOptions>>;
 
 export interface Context {
-	cwd: string;
 	pkg: any;
 	typingsFile: string;
 	testFiles: string[];
 	config: Config;
+	options: Options
+}
+
+export interface Options {
+	cwd: string;
+	verify: boolean;
+	writeSnapshot: boolean;
+	sizeDelta: number;
 }
 
 export enum DiagnosticCode {
@@ -36,6 +43,17 @@ export interface Diagnostic {
 	severity: 'error' | 'warning';
 	line?: number;
 	column?: number;
+}
+
+export interface ProjectSizeStats {
+	typeCount: number;
+	memoryUsage: number;
+	relationCacheSizes: object;
+}
+
+export interface RunResults {
+	diagnostics: Diagnostic[];
+	stats: ProjectSizeStats;
 }
 
 export interface Location {

--- a/source/lib/memory-validator.ts
+++ b/source/lib/memory-validator.ts
@@ -1,0 +1,85 @@
+import * as path from 'path';
+import {ProjectSizeStats, Diagnostic, Context} from './interfaces';
+import * as pathExists from 'path-exists';
+import {writeFileSync, readFileSync} from 'fs';
+
+const statsFilename = '.tsd-memory-check-results.json';
+
+const findStatsFile = async (context: Context) => {
+	const rootFileExists = await pathExists(path.join(context.options.cwd, statsFilename));
+	if (rootFileExists) {
+		return path.join(context.options.cwd, statsFilename);
+	}
+
+	const subfolderFileExists = await pathExists(path.join(context.options.cwd, '.tsd', statsFilename));
+	if (subfolderFileExists) {
+		return path.join(context.options.cwd, '.tsd', statsFilename);
+	}
+
+	return;
+};
+
+/**
+ * Get a list of TypeScript diagnostics, and memory size within the current context.
+ *
+ * @param context - The context object.
+ * @param runStats - An object which has the memory stats from a run.
+ * @returns An array of diagnostics
+ */
+export const verifyMemorySize = async (context: Context, runStats: ProjectSizeStats): Promise<Diagnostic[]> => {
+	const existingStatsPath = await findStatsFile(context);
+
+	const writeJSON = (message: string) => {
+		const rootFilePath = path.join(context.options.cwd, statsFilename);
+		writeFileSync(rootFilePath, JSON.stringify(runStats, null, '  '), 'utf8');
+		return [{
+			fileName: rootFilePath,
+			message,
+			severity: 'warning' as 'warning'
+		}];
+	};
+
+	if (!existingStatsPath) {
+		return writeJSON('Recording the stats for memory size in your types');
+	}
+
+	if (context.options.writeSnapshot) {
+		return writeJSON('Updated the stats for memory size in your types');
+	}
+
+	const existingResults = JSON.parse(readFileSync(existingStatsPath, 'utf8')) as ProjectSizeStats;
+	const validate = (prev: number, current: number) => {
+		const largerPrev = (prev / 100) * (context.options.sizeDelta + 100);
+		return current < largerPrev;
+	};
+
+	const names: string[] = [];
+
+	// This is an approximation, and would likely change between versions, so the number is
+	// conservative
+	const typescriptTypes = 8500;
+
+	if (!validate(existingResults.typeCount - typescriptTypes, runStats.typeCount - typescriptTypes)) {
+		names.push(`- Type Count raised by ${runStats.typeCount - existingResults.typeCount}`);
+	}
+
+	if (!validate(existingResults.memoryUsage, runStats.memoryUsage)) {
+		names.push(`- Memory usage raised by ${runStats.typeCount / existingResults.typeCount * 100}%`);
+	}
+
+	if (names.length) {
+		const messages = [
+			'Failed due to memory changes for types being raised. Higher numbers',
+			'can slow down the editor experience for consumers.',
+			'If you\'d like to update the fixtures to keep these changes re-run tsd with --write',
+			'', ...names];
+
+		return [{
+			fileName: existingStatsPath,
+			message: messages.join('\n           '),
+			severity: 'error' as 'error'
+		}];
+	}
+
+	return [];
+};

--- a/source/lib/rules/files-property.ts
+++ b/source/lib/rules/files-property.ts
@@ -23,7 +23,7 @@ export default (context: Context): Diagnostic[] => {
 		return [];
 	}
 
-	const content = fs.readFileSync(path.join(context.cwd, 'package.json'), 'utf8');
+	const content = fs.readFileSync(path.join(context.options.cwd, 'package.json'), 'utf8');
 
 	return [
 		{

--- a/source/lib/rules/types-property.ts
+++ b/source/lib/rules/types-property.ts
@@ -13,7 +13,7 @@ export default (context: Context): Diagnostic[] => {
 	const {pkg} = context;
 
 	if (!pkg.types && pkg.typings) {
-		const content = fs.readFileSync(path.join(context.cwd, 'package.json'), 'utf8');
+		const content = fs.readFileSync(path.join(context.options.cwd, 'package.json'), 'utf8');
 
 		return [
 			{

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -189,7 +189,7 @@ test('support setting a custom test directory', async t => {
 test('expectError for functions', async t => {
 	const diagnostics = await m({cwd: path.join(__dirname, 'fixtures/expect-error/functions')});
 
-	t.true(diagnostics.length === 1);
+	t.true(diagnostics.length === 1, `Diagnostics: ${diagnostics.map(d => d.message)}`);
 
 	t.true(diagnostics[0].column === 0);
 	t.true(diagnostics[0].line === 5);


### PR DESCRIPTION
Problem: We can verify types in definitely typed aren't causing slowdowns for folks with tooling  on that repo. There are no tools for doing that anywhere else. 

I'd like tsd to be the tool we recommend in the TS guides for how to create dts files for JS projects, as I think it's a simpler and more useful abstraction that dtslint for most projects. I'd like for people to be able to do two things with tsd: validate their types, and for larger projects - ensure they don't accidentally merge PRs which affect performance.

Not many libs should need a tool like this, but ones which offer presentation layers (e.g. CSS in JS libs) tend to have accidental drastic memory increases. 

---

This PR doesn't have docs and tests yet, and access TS private APIs ( https://github.com/microsoft/TypeScript/issues/33345 ) - but I'm opening it to start chatting about the structure and what you want tsd to be vs what I've modified it to be.