### PR TITLE
Fix yargs-parser vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,15 +42,15 @@
 	"dependencies": {
 		"eslint-formatter-pretty": "^1.3.0",
 		"globby": "^9.1.0",
-		"meow": "^5.0.0",
+		"meow": "^6.1.1",
 		"path-exists": "^3.0.0",
 		"read-pkg-up": "^4.0.0",
-		"update-notifier": "^2.5.0"
+		"update-notifier": "^4.1.0"
 	},
 	"devDependencies": {
 		"@types/node": "^11.10.4",
 		"@types/react": "^16.9.2",
-		"@types/update-notifier": "^2.2.0",
+		"@types/update-notifier": "^4.1.0",
 		"ava": "^1.4.1",
 		"cpy-cli": "^2.0.0",
 		"del-cli": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	"scripts": {
 		"prepublishOnly": "npm run build",
 		"pretest": "npm run build && cpy \"./**/**\" \"../../../dist/test/fixtures/\" --parents --cwd=source/test/fixtures",
-		"test": "npm run lint && ava dist/test/test.js",
+		"test": "npm run lint && ava dist/test/test.js -T 60s",
 		"build": "npm run clean && tsc && chmod +x dist/cli.js",
 		"clean": "del-cli dist",
 		"lint": "tslint -p . --format stylish"
@@ -51,7 +51,7 @@
 		"@types/node": "^11.10.4",
 		"@types/react": "^16.9.2",
 		"@types/update-notifier": "^4.1.0",
-		"ava": "^1.4.1",
+		"ava": "^3.8.1",
 		"cpy-cli": "^2.0.0",
 		"del-cli": "^1.1.0",
 		"execa": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"@types/react": "^16.9.2",
 		"@types/update-notifier": "^4.1.0",
 		"ava": "^3.8.1",
-		"cpy-cli": "^2.0.0",
+		"cpy-cli": "^3.1.1",
 		"del-cli": "^1.1.0",
 		"execa": "^3.3.0",
 		"react": "^16.9.0",

--- a/source/cli.ts
+++ b/source/cli.ts
@@ -18,7 +18,7 @@ const cli = meow(`
 `);
 
 (async () => {	// tslint:disable-line:no-floating-promises
-	updateNotifier({pkg: cli.pkg}).notify();
+	updateNotifier({pkg: (cli.pkg as updateNotifier.Package)}).notify();
 
 	try {
 		const options = cli.input.length > 0 ? {cwd: cli.input[0]} : undefined;

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -4,11 +4,11 @@ import {verify} from './fixtures/utils';
 import tsd from '..';
 
 test('throw if no type definition was found', async t => {
-	await t.throwsAsync(tsd({cwd: path.join(__dirname, 'fixtures/no-tsd')}), 'The type definition `index.d.ts` does not exist. Create one and try again.');
+	await t.throwsAsync(tsd({cwd: path.join(__dirname, 'fixtures/no-tsd')}), {instanceOf: Error, message: 'The type definition `index.d.ts` does not exist. Create one and try again.'});
 });
 
 test('throw if no test is found', async t => {
-	await t.throwsAsync(tsd({cwd: path.join(__dirname, 'fixtures/no-test')}), 'The test file `index.test-d.ts` or `index.test-d.tsx` does not exist. Create one and try again.');
+	await t.throwsAsync(tsd({cwd: path.join(__dirname, 'fixtures/no-test')}), {instanceOf: Error, message: 'The test file `index.test-d.ts` or `index.test-d.tsx` does not exist. Create one and try again.'});
 });
 
 test('return diagnostics', async t => {


### PR DESCRIPTION
`yargs-parser` had a security [vulnerability](https://snyk.io/vuln/SNYK-JS-YARGSPARSER-560381) that has been fixed in the latest release.

This PR updates `meow`, `ava` and `cpy-cli` to the latest versions as these versions include the fixed `yargs-parser` as dependency.