### PR TITLE
Add support for globbing patterns in files property - fixes #69

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"author": {
 		"name": "Sam Verschueren",
 		"email": "sam.verschueren@gmail.com",
-		"url": "https://github.com/SamVerschueren"
+		"url": "github.com/SamVerschueren"
 	},
 	"main": "dist/index.js",
 	"typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"author": {
 		"name": "Sam Verschueren",
 		"email": "sam.verschueren@gmail.com",
-		"url": "github.com/SamVerschueren"
+		"url": "https://github.com/SamVerschueren"
 	},
 	"main": "dist/index.js",
 	"typings": "dist/index.d.ts",

--- a/source/lib/rules/files-property.ts
+++ b/source/lib/rules/files-property.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
+import globby from 'globby';
 import {Context, Diagnostic} from '../interfaces';
 import {getJSONPropertyPosition} from '../utils';
 
@@ -17,7 +18,7 @@ export default (context: Context): Diagnostic[] => {
 	}
 
 	const normalizedTypingsFile = path.normalize(typingsFile);
-	const normalizedFiles = (pkg.files as string[]).map(path.normalize);
+	const normalizedFiles = globby.sync(pkg.files as string[], {cwd: context.cwd}).map(path.normalize);
 
 	if (normalizedFiles.includes(normalizedTypingsFile)) {
 		return [];

--- a/source/test/fixtures/files-folder/package.json
+++ b/source/test/fixtures/files-folder/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "foo",
+	"files": [
+		"dist"
+	],
+    "types": "dist/index.d.ts"
+}

--- a/source/test/fixtures/files-folder/package.json
+++ b/source/test/fixtures/files-folder/package.json
@@ -3,5 +3,5 @@
 	"files": [
 		"dist"
 	],
-    "types": "dist/index.d.ts"
+	"types": "dist/index.d.ts"
 }

--- a/source/test/fixtures/files-glob/package.json
+++ b/source/test/fixtures/files-glob/package.json
@@ -4,5 +4,5 @@
 		"dist/**/*.d.ts",
 		"dist/**/*.js"
 	],
-    "types": "dist/index.d.ts"
+	"types": "dist/index.d.ts"
 }

--- a/source/test/fixtures/files-glob/package.json
+++ b/source/test/fixtures/files-glob/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "foo",
+	"files": [
+		"dist/**/*.d.ts",
+		"dist/**/*.js"
+	],
+    "types": "dist/index.d.ts"
+}

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -36,6 +36,18 @@ test('fail if typings file is not part of `files` list', async t => {
 	]);
 });
 
+test('allow specifying folders containing typings file in `files` list', async t => {
+	const diagnostics = await tsd({cwd: path.join(__dirname, 'fixtures/files-folder')});
+
+	verify(t, diagnostics, []);
+});
+
+test('allow specifying glob patterns containing typings file in `files` list', async t => {
+	const diagnostics = await tsd({cwd: path.join(__dirname, 'fixtures/files-glob')});
+
+	verify(t, diagnostics, []);
+});
+
 test('fail if `typings` property is used instead of `types`', async t => {
 	const diagnostics = await tsd({cwd: path.join(__dirname, 'fixtures/types-property/typings')});
 


### PR DESCRIPTION
files can contain directories and globs: https://docs.npmjs.com/files/package.json#files

This fixes it, including tests.

It also fixes a wrong url in the package.json