### PR TITLE
Downgrade eslint-formatter-pretty to support Node.js 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"typedefinitions"
 	],
 	"dependencies": {
-		"eslint-formatter-pretty": "^4.0.0",
+		"eslint-formatter-pretty": "^3.0.1",
 		"globby": "^11.0.1",
 		"meow": "^7.0.1",
 		"path-exists": "^4.0.0",


### PR DESCRIPTION
eslint-formatter-pretty@4 requires node 10, and breaks compatibility with 8:

https://github.com/sindresorhus/eslint-formatter-pretty/commit/2b21776806574f6cfb255c8ffc3479f0a72db00c#diff-168726dbe96b3ce427e7fedce31bb0bc

Noticed this in a failing test when upgrading tsd to 0.12:

```
/home/travis/build/bendrucker/snakecase-keys/node_modules/eslint-formatter-pretty/index.js:127
			} catch {
			        ^

SyntaxError: Unexpected token {
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:617:28)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/travis/build/bendrucker/snakecase-keys/node_modules/tsd/dist/lib/formatter.js:3:19)
```