### PR TITLE
Add flag for typings file to cli

### DIFF
--- a/source/cli.ts
+++ b/source/cli.ts
@@ -8,6 +8,9 @@ const cli = meow(`
 	Usage
 	  $ tsd [path]
 
+	Options
+	  --typings-file, -t 	What typings file to test
+
 	Examples
 	  $ tsd /path/to/project
 
@@ -15,13 +18,24 @@ const cli = meow(`
 
 	    index.test-d.ts
 	    ✖  10:20  Argument of type string is not assignable to parameter of type number.
-`);
+`, {
+	flags: {
+		typingsFile: {
+			alias: 't',
+			isRequired: false,
+			type: 'string'
+		}
+	}
+});
 
 (async () => {	// tslint:disable-line:no-floating-promises
 	updateNotifier({pkg: cli.pkg as updateNotifier.Package}).notify();
 
 	try {
-		const options = cli.input.length > 0 ? {cwd: cli.input[0]} : undefined;
+		const options = {
+			cwd: cli.input.length > 0 ? cli.input[0] : process.cwd(),
+			...cli.flags
+		};
 
 		const diagnostics = await tsd(options);
 


### PR DESCRIPTION
Work has started, that allows to specify the typings file manually. Currently this is implemented for the tsd function but not for the tsd cli. This PR adds a flag to cli for specifying a typings file.
