### PR TITLE
Detect "Type X has no properties in common with type Y" in `expectError` (TS2559)

### DIFF
--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -23,7 +23,8 @@ const expectErrordiagnosticCodesToIgnore = new Set<DiagnosticCode>([
 	DiagnosticCode.GenericTypeRequiresTypeArguments,
 	DiagnosticCode.ExpectedArgumentsButGotOther,
 	DiagnosticCode.NoOverloadMatches,
-	DiagnosticCode.PropertyMissingInType1ButRequiredInType2
+	DiagnosticCode.PropertyMissingInType1ButRequiredInType2,
+	DiagnosticCode.TypeHasNoPropertiesInCommonWith
 ]);
 
 /**

--- a/source/lib/interfaces.ts
+++ b/source/lib/interfaces.ts
@@ -28,6 +28,7 @@ export enum DiagnosticCode {
 	ArgumentTypeIsNotAssignableToParameterType = 2345,
 	CannotAssignToReadOnlyProperty = 2540,
 	ExpectedArgumentsButGotOther = 2554,
+	TypeHasNoPropertiesInCommonWith = 2559,
 	NoOverloadMatches = 2769,
 	PropertyMissingInType1ButRequiredInType2 = 2741,
 }

--- a/source/test/fixtures/expect-error/values/index.d.ts
+++ b/source/test/fixtures/expect-error/values/index.d.ts
@@ -9,4 +9,8 @@ export const foo: {readonly bar: string};
 
 export function hasProperty(property: {name: string}): boolean;
 
+export type HasKey<K extends string, V = unknown> = {[P in K]?: V};
+
+export function getFoo<T extends HasKey<'foo'>>(obj: T): T['foo'];
+
 export interface Options<T> {}

--- a/source/test/fixtures/expect-error/values/index.test-d.ts
+++ b/source/test/fixtures/expect-error/values/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectError} from '../../../..';
-import {default as one, foo, hasProperty, Options} from '.';
+import {default as one, foo, getFoo, HasKey, hasProperty, Options} from '.';
 
 expectError<string>(1);
 expectError<string>('fo');
@@ -20,3 +20,5 @@ expectError(hasProperty({name: 1}));
 expectError(one(1));
 expectError(one(1, 2, 3));
 expectError({} as Options);
+
+expectError(getFoo({bar: 1} as HasKey<'bar'>));


### PR DESCRIPTION
Fixes #77.
