### PR TITLE
Allow `expectError` directives to detect parameter count mismatches

### DIFF
--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -24,6 +24,8 @@ const expectErrordiagnosticCodesToIgnore = new Set<DiagnosticCode>([
 	DiagnosticCode.TypeDoesNotSatisfyTheConstraint,
 	DiagnosticCode.GenericTypeRequiresTypeArguments,
 	DiagnosticCode.ExpectedArgumentsButGotOther,
+	DiagnosticCode.NoOverloadExpectsCountOfArguments,
+	DiagnosticCode.NoOverloadExpectsCountOfTypeArguments,
 	DiagnosticCode.NoOverloadMatches,
 	DiagnosticCode.PropertyMissingInType1ButRequiredInType2,
 	DiagnosticCode.TypeHasNoPropertiesInCommonWith,

--- a/source/lib/interfaces.ts
+++ b/source/lib/interfaces.ts
@@ -34,8 +34,10 @@ export enum DiagnosticCode {
 	ExpressionNotCallable = 2349,
 	OnlyVoidFunctionIsNewCallable = 2350,
 	ExpressionNotConstructable = 2351,
+	NoOverloadExpectsCountOfArguments = 2575,
 	ThisContextOfTypeNotAssignableToMethodOfThisType = 2684,
 	PropertyMissingInType1ButRequiredInType2 = 2741,
+	NoOverloadExpectsCountOfTypeArguments = 2743,
 	NoOverloadMatches = 2769,
 	NewExpressionTargetLackingConstructSignatureHasAnyType = 7009,
 }

--- a/source/test/fixtures/expect-error/functions/index.d.ts
+++ b/source/test/fixtures/expect-error/functions/index.d.ts
@@ -6,6 +6,11 @@ declare const one: {
 
 export default one;
 
+export const two: {
+	(foo: string): string;
+	(foo: string, bar: string, baz: string): string;
+};
+
 export const three: {
 	(foo: '*'): string;
 	(foo: 'a' | 'b'): string;

--- a/source/test/fixtures/expect-error/functions/index.js
+++ b/source/test/fixtures/expect-error/functions/index.js
@@ -1,3 +1,11 @@
 module.exports.default = (foo, bar) => foo + bar;
 
+module.exports.two = (foo, bar, baz) => {
+	if (foo!= null && bar != null && baz != null) {
+		return foo + bar + baz;
+	} else {
+		return foo;
+	}
+};
+
 exports.three = (foo) => 'a';

--- a/source/test/fixtures/expect-error/functions/index.test-d.ts
+++ b/source/test/fixtures/expect-error/functions/index.test-d.ts
@@ -1,8 +1,10 @@
 import {expectError} from '../../../..';
-import one, {three} from '.';
+import one, {two, three} from '.';
 
 expectError(one(true, true));
 expectError(one('foo', 'bar'));
+
+expectError(two('foo', 'bar'));
 
 // Produces multiple type checker errors in a single `expectError` assertion
 expectError(three(['a', 'bad']));

--- a/source/test/fixtures/expect-error/generics/index.d.ts
+++ b/source/test/fixtures/expect-error/generics/index.d.ts
@@ -3,3 +3,6 @@ declare const one: {
 };
 
 export default one;
+
+export function two<T1>(foo: T1): T1;
+export function two<T1, T2, T3 extends T2>(foo: T1, bar: T2): T3;

--- a/source/test/fixtures/expect-error/generics/index.js
+++ b/source/test/fixtures/expect-error/generics/index.js
@@ -1,3 +1,11 @@
 module.exports.default = (foo, bar) => {
 	return foo + bar;
 };
+
+exports.two = (foo, bar) => {
+	if (foo != null && bar != null) {
+		return bar;
+	} else {
+		return foo;
+	}
+};

--- a/source/test/fixtures/expect-error/generics/index.test-d.ts
+++ b/source/test/fixtures/expect-error/generics/index.test-d.ts
@@ -1,6 +1,8 @@
 import {expectError} from '../../../..';
-import one from '.';
+import one, {two} from '.';
 
 expectError(one(true, true));
 
 expectError(one<number>(1, 2));
+
+expectError(two<number, string>(1, 'bar'));


### PR DESCRIPTION
This PR extends the errors swallowed by usage of `expectError` for the following 2 errors:

- function argument count mismatch for overloaded functions
- function type argument count mismatch for overloaded functions