### PR TITLE
Handle multiple diagnostic errors in a single `expectError` assertion

### DIFF
--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -35,7 +35,9 @@ type IgnoreDiagnosticResult = 'preserve' | 'ignore' | Location;
  *
  * @param diagnostic - The diagnostic to validate.
  * @param expectedErrors - Map of the expected errors.
- * @returns Boolean indicating if the diagnostic should be ignored or not.
+ * @returns Whether the diagnostic should be `'preserve'`d, `'ignore'`d or, in case that
+ * the diagnostic is reported from inside of an `expectError` assertion, the `Location`
+ * of the assertion.
  */
 const ignoreDiagnostic = (
 	diagnostic: TSDiagnostic,
@@ -91,6 +93,7 @@ export const getDiagnostics = (context: Context): Diagnostic[] => {
 		}
 
 		const ignoreDiagnosticResult = ignoreDiagnostic(diagnostic, expectedErrors);
+
 		if (ignoreDiagnosticResult !== 'preserve') {
 			if (ignoreDiagnosticResult !== 'ignore') {
 				expectedErrorsLocationsWithFoundDiagnostics.push(ignoreDiagnosticResult);

--- a/source/lib/parser.ts
+++ b/source/lib/parser.ts
@@ -42,15 +42,19 @@ export const extractAssertions = (program: Program): Map<Assertion, Set<CallExpr
 	return assertions;
 };
 
+export type ExpectedError = Pick<Diagnostic, 'fileName' | 'line' | 'column'>;
+
 /**
  * Loop over all the error assertion nodes and convert them to a location map.
  *
  * @param assertions - Assertion map.
  */
-export const parseErrorAssertionToLocation = (assertions: Map<Assertion, Set<CallExpression>>) => {
+export const parseErrorAssertionToLocation = (
+	assertions: Map<Assertion, Set<CallExpression>>
+): Map<Location, ExpectedError> => {
 	const nodes = assertions.get(Assertion.EXPECT_ERROR);
 
-	const expectedErrors = new Map<Location, Pick<Diagnostic, 'fileName' | 'line' | 'column'>>();
+	const expectedErrors = new Map<Location, ExpectedError>();
 
 	if (!nodes) {
 		// Bail out if we don't have any error nodes

--- a/source/test/fixtures/expect-error/functions/index.d.ts
+++ b/source/test/fixtures/expect-error/functions/index.d.ts
@@ -5,3 +5,10 @@ declare const one: {
 };
 
 export default one;
+
+export const three: {
+	(foo: '*'): string;
+	(foo: 'a' | 'b'): string;
+	(foo: ReadonlyArray<'a' | 'b'>): string;
+	(foo: never): string;
+};

--- a/source/test/fixtures/expect-error/functions/index.js
+++ b/source/test/fixtures/expect-error/functions/index.js
@@ -1,3 +1,3 @@
-module.exports.default = (foo, bar) => {
-	return foo + bar;
-};
+module.exports.default = (foo, bar) => foo + bar;
+
+exports.three = (foo) => 'a';

--- a/source/test/fixtures/expect-error/functions/index.test-d.ts
+++ b/source/test/fixtures/expect-error/functions/index.test-d.ts
@@ -1,5 +1,8 @@
 import {expectError} from '../../../..';
-import one from '.';
+import one, {three} from '.';
 
 expectError(one(true, true));
 expectError(one('foo', 'bar'));
+
+// Produces multiple type checker errors in a single `expectError` assertion
+expectError(three(['a', 'bad']));


### PR DESCRIPTION
Fixes #87