### PR TITLE
Upgrade to ts@4.3, allow `expectError` to detect `override` related errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"typedefinitions"
 	],
 	"dependencies": {
-		"@tsd/typescript": "^4.2.4",
+		"@tsd/typescript": "^4.3.2",
 		"eslint-formatter-pretty": "^4.0.0",
 		"globby": "^11.0.1",
 		"meow": "^9.0.0",

--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -35,6 +35,8 @@ const expectErrordiagnosticCodesToIgnore = new Set<DiagnosticCode>([
 	DiagnosticCode.OnlyVoidFunctionIsNewCallable,
 	DiagnosticCode.ExpressionNotConstructable,
 	DiagnosticCode.NewExpressionTargetLackingConstructSignatureHasAnyType,
+	DiagnosticCode.MemberCannotHaveOverrideModifierBecauseItIsNotDeclaredInBaseClass,
+	DiagnosticCode.MemberMustHaveOverrideModifier,
 ]);
 
 type IgnoreDiagnosticResult = 'preserve' | 'ignore' | Location;

--- a/source/lib/interfaces.ts
+++ b/source/lib/interfaces.ts
@@ -39,6 +39,8 @@ export enum DiagnosticCode {
 	PropertyMissingInType1ButRequiredInType2 = 2741,
 	NoOverloadExpectsCountOfTypeArguments = 2743,
 	NoOverloadMatches = 2769,
+	MemberCannotHaveOverrideModifierBecauseItIsNotDeclaredInBaseClass = 4113,
+	MemberMustHaveOverrideModifier = 4114,
 	NewExpressionTargetLackingConstructSignatureHasAnyType = 7009,
 }
 

--- a/source/test/fixtures/expect-error/classes/index.test-d.ts
+++ b/source/test/fixtures/expect-error/classes/index.test-d.ts
@@ -4,3 +4,11 @@ import {Foo} from '.';
 const numberFoo = new Foo<number>();
 
 expectError(numberFoo.bar());
+
+expectError(class extends Foo<string> {
+	bar(): void {}
+});
+
+expectError(class extends Foo<string> {
+	override foo(): void {}
+});

--- a/source/test/fixtures/expect-error/classes/package.json
+++ b/source/test/fixtures/expect-error/classes/package.json
@@ -1,3 +1,8 @@
 {
-	"name": "foo"
+	"name": "foo",
+	"tsd": {
+		"compilerOptions": {
+			"noImplicitOverride": true
+		}
+	}
 }


### PR DESCRIPTION
Fixes #106