### PR TITLE
Ignore errors from libs in `node_modules` folders

### DIFF
--- a/source/lib/assertions/index.ts
+++ b/source/lib/assertions/index.ts
@@ -13,7 +13,7 @@ export enum Assertion {
 }
 
 // List of diagnostic handlers attached to the assertion
-const assertionHandlers = new Map<string, Handler | Handler[]>([
+const assertionHandlers = new Map<Assertion, Handler>([
 	[Assertion.EXPECT_TYPE, isIdentical],
 	[Assertion.EXPECT_NOT_TYPE, isNotIdentical],
 	[Assertion.EXPECT_NOT_ASSIGNABLE, isNotAssignable],
@@ -39,12 +39,7 @@ export const handle = (typeChecker: TypeChecker, assertions: Map<Assertion, Set<
 			continue;
 		}
 
-		const handlers = Array.isArray(handler) ? handler : [handler];
-
-		// Iterate over the handlers and invoke them
-		for (const fn of handlers) {
-			diagnostics.push(...fn(typeChecker, nodes));
-		}
+		diagnostics.push(...handler(typeChecker, nodes));
 	}
 
 	return diagnostics;

--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -99,7 +99,10 @@ export const getDiagnostics = (context: Context): Diagnostic[] => {
 	const expectedErrorsLocationsWithFoundDiagnostics: Location[] = [];
 
 	for (const diagnostic of tsDiagnostics) {
-		if (!diagnostic.file) {
+		/* Filter out all diagnostic messages without a file or from node_modules directories, files under
+		 * node_modules are most definitely not under test.
+		 */
+		if (!diagnostic.file || /[/\\]node_modules[/\\]/.test(diagnostic.file.fileName)) {
 			continue;
 		}
 

--- a/source/test/fixtures/exclude-node-modules/index.d.ts
+++ b/source/test/fixtures/exclude-node-modules/index.d.ts
@@ -1,0 +1,4 @@
+export default function (foo: number): number | null;
+
+export type Foo = Bar;
+

--- a/source/test/fixtures/exclude-node-modules/index.js
+++ b/source/test/fixtures/exclude-node-modules/index.js
@@ -1,0 +1,3 @@
+module.exports.default = foo => {
+	return foo > 0 ? foo : null;
+};

--- a/source/test/fixtures/exclude-node-modules/index.test-d.ts
+++ b/source/test/fixtures/exclude-node-modules/index.test-d.ts
@@ -1,0 +1,4 @@
+import {expectType} from '../../..';
+import aboveZero from '.';
+
+expectType<number | null>(aboveZero(1));

--- a/source/test/fixtures/exclude-node-modules/package.json
+++ b/source/test/fixtures/exclude-node-modules/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "foo",
+	"tsd": {
+		"compilerOptions": {
+			"noLib": true
+		}
+	}
+}


### PR DESCRIPTION
I've tried a few different things here but it seems that ignoring diagnostics from `node_modules` folders is a good enough workaround.

An actual solution for this would be support from `tsc` to allow type-checking project-local `.d.ts` files while skipping `.d.ts` files from `node_modules`. The way things are right now, `skipLibCheck` will disable type-checking `.d.ts` files everywhere which we definitely don't want. On the other hand, skipping type-checking for types from `node_modules` would bring enormous performance improvements, most time is spent by checking types there.

I've also tried to mess a bit with `tsc`, mostly by monkey-patching stuff. The problem is that it's pretty much impossible to know in advance which `.d.ts` files are required to correctly type check an application and which ones not. It mostly boils down to `.d.ts` files exposing stuff in the global scope or declaring modules with different names than the module they belong to. Most other cases should be discoverable by analyzing for `import`s, `<reference ...` directives and the like. 

Fixes #45
Fixes #76
Fixes #30