### PR TITLE
Add tests for identicality checks of `any`/`never` type parameters to `expectType`/`expectNotType`

### DIFF
--- a/source/test/fixtures/identicality/identical/index.test-d.ts
+++ b/source/test/fixtures/identicality/identical/index.test-d.ts
@@ -6,3 +6,8 @@ expectType<number>(concat(1, 2));
 
 expectType<any>(concat(1, 2));
 expectType<string | number>(concat('unicorn', 'rainbow'));
+
+expectType<false>(concat(1, 2) as any);
+
+expectType<string>('' as never);
+expectType<any>('' as never);

--- a/source/test/fixtures/identicality/not-identical/index.test-d.ts
+++ b/source/test/fixtures/identicality/not-identical/index.test-d.ts
@@ -5,3 +5,6 @@ expectNotType<number>(concat('foo', 'bar'));
 expectNotType<string | number>(concat('foo', 'bar'));
 
 expectNotType<string>(concat('unicorn', 'rainbow'));
+
+expectNotType<false>(concat('foo', 'bar') as any);
+expectNotType<any>(concat('foo', 'bar') as any);

--- a/source/test/identicality.ts
+++ b/source/test/identicality.ts
@@ -8,7 +8,10 @@ test('identical', async t => {
 
 	verify(t, diagnostics, [
 		[7, 0, 'error', 'Parameter type `any` is not identical to argument type `number`.'],
-		[8, 0, 'error', 'Parameter type `string | number` is declared too wide for argument type `string`.']
+		[8, 0, 'error', 'Parameter type `string | number` is declared too wide for argument type `string`.'],
+		[10, 0, 'error', 'Parameter type `false` is not identical to argument type `any`.'],
+		[12, 0, 'error', 'Parameter type `string` is declared too wide for argument type `never`.'],
+		[13, 0, 'error', 'Parameter type `any` is declared too wide for argument type `never`.'],
 	]);
 });
 
@@ -16,6 +19,7 @@ test('not identical', async t => {
 	const diagnostics = await tsd({cwd: path.join(__dirname, 'fixtures/identicality/not-identical')});
 
 	verify(t, diagnostics, [
-		[7, 0, 'error', 'Parameter type `string` is identical to argument type `string`.']
+		[7, 0, 'error', 'Parameter type `string` is identical to argument type `string`.'],
+		[10, 0, 'error', 'Parameter type `any` is identical to argument type `any`.'],
 	]);
 });


### PR DESCRIPTION
The problems described in #78 and #82 are not reproducible in current version of `tsd`. I've tested it with different versions of `typescript`, down to 4.0.

Closes #78
Closes #82