### PR TITLE
Report the number of evaluated tests alongside with diagnostics

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -204,10 +204,13 @@ You can use the programmatic API to retrieve the diagnostics and do something wi
 import tsd from 'tsd';
 
 (async () => {
-	const diagnostics = await tsd();
+	const {diagnostics, testCount} = await tsd();
 
-	console.log(diagnostics.length);
-	//=> 2
+	// The list of diagnostics if any or just an empty array.
+	console.log(diagnostics);
+
+	// The number of tests evaluated.
+	console.log(testCount)
 })();
 ```
 

--- a/source/cli.ts
+++ b/source/cli.ts
@@ -20,10 +20,10 @@ const cli = meow(`
 	try {
 		const options = cli.input.length > 0 ? {cwd: cli.input[0]} : undefined;
 
-		const extendedDiagnostics = await tsd(options);
+		const {diagnostics} = await tsd(options);
 
-		if (extendedDiagnostics.diagnostics.length > 0) {
-			throw new Error(formatter(extendedDiagnostics));
+		if (diagnostics.length > 0) {
+			throw new Error(formatter(diagnostics));
 		}
 	} catch (error: unknown) {
 		if (error && typeof (error as Error).message === 'string') {

--- a/source/cli.ts
+++ b/source/cli.ts
@@ -20,10 +20,10 @@ const cli = meow(`
 	try {
 		const options = cli.input.length > 0 ? {cwd: cli.input[0]} : undefined;
 
-		const diagnostics = await tsd(options);
+		const extendedDiagnostics = await tsd(options);
 
-		if (diagnostics.length > 0) {
-			throw new Error(formatter(diagnostics));
+		if (extendedDiagnostics.diagnostics.length > 0) {
+			throw new Error(formatter(extendedDiagnostics));
 		}
 	} catch (error: unknown) {
 		if (error && typeof (error as Error).message === 'string') {

--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -4,7 +4,7 @@ import {
 	Diagnostic as TSDiagnostic
 } from '@tsd/typescript';
 import {ExpectedError, extractAssertions, parseErrorAssertionToLocation} from './parser';
-import {Diagnostic, DiagnosticCode, Context, Location} from './interfaces';
+import {Context, Diagnostic, DiagnosticCode, ExtendedDiagnostic, Location} from './interfaces';
 import {handle} from './assertions';
 
 // List of diagnostic codes that should be ignored in general
@@ -84,7 +84,8 @@ const ignoreDiagnostic = (
  * @param context - The context object.
  * @returns List of diagnostics
  */
-export const getDiagnostics = (context: Context): Diagnostic[] => {
+export const getDiagnostics = (context: Context): ExtendedDiagnostic => {
+	let testCount = 0;
 	const diagnostics: Diagnostic[] = [];
 
 	const program = createProgram(context.testFiles, context.config.compilerOptions);
@@ -94,6 +95,10 @@ export const getDiagnostics = (context: Context): Diagnostic[] => {
 		.concat(program.getSyntacticDiagnostics());
 
 	const assertions = extractAssertions(program);
+
+	for (const assertion of assertions) {
+		testCount += assertion[1].size;
+	}
 
 	diagnostics.push(...handle(program.getTypeChecker(), assertions));
 
@@ -142,5 +147,5 @@ export const getDiagnostics = (context: Context): Diagnostic[] => {
 		});
 	}
 
-	return diagnostics;
+	return {testCount, diagnostics};
 };

--- a/source/lib/formatter.ts
+++ b/source/lib/formatter.ts
@@ -1,5 +1,5 @@
 import formatter from 'eslint-formatter-pretty';
-import {Diagnostic} from './interfaces';
+import {Diagnostic, ExtendedDiagnostic} from './interfaces';
 
 interface FileWithDiagnostics {
 	filePath: string;
@@ -11,10 +11,11 @@ interface FileWithDiagnostics {
 /**
  * Format the TypeScript diagnostics to a human readable output.
  *
- * @param diagnostics - List of TypeScript diagnostics.
+ * @param extendedDiagnostics - Object containing list of TypeScript diagnostics and test count.
  * @returns Beautiful diagnostics output
  */
-export default (diagnostics: Diagnostic[]): string => {
+export default (extendedDiagnostics: ExtendedDiagnostic) => {
+	const {diagnostics} = extendedDiagnostics;
 	const fileMap = new Map<string, FileWithDiagnostics>();
 
 	for (const diagnostic of diagnostics) {

--- a/source/lib/formatter.ts
+++ b/source/lib/formatter.ts
@@ -14,7 +14,7 @@ interface FileWithDiagnostics {
  * @param diagnostics - List of TypeScript diagnostics.
  * @returns Beautiful diagnostics output
  */
-export default (diagnostics: Diagnostic[]) => {
+export default (diagnostics: Diagnostic[]): string => {
 	const fileMap = new Map<string, FileWithDiagnostics>();
 
 	for (const diagnostic of diagnostics) {

--- a/source/lib/formatter.ts
+++ b/source/lib/formatter.ts
@@ -1,5 +1,5 @@
 import formatter from 'eslint-formatter-pretty';
-import {Diagnostic, ExtendedDiagnostic} from './interfaces';
+import {Diagnostic} from './interfaces';
 
 interface FileWithDiagnostics {
 	filePath: string;
@@ -11,11 +11,10 @@ interface FileWithDiagnostics {
 /**
  * Format the TypeScript diagnostics to a human readable output.
  *
- * @param extendedDiagnostics - Object containing list of TypeScript diagnostics and test count.
+ * @param diagnostics - List of TypeScript diagnostics.
  * @returns Beautiful diagnostics output
  */
-export default (extendedDiagnostics: ExtendedDiagnostic) => {
-	const {diagnostics} = extendedDiagnostics;
+export default (diagnostics: Diagnostic[]) => {
 	const fileMap = new Map<string, FileWithDiagnostics>();
 
 	for (const diagnostic of diagnostics) {

--- a/source/lib/index.ts
+++ b/source/lib/index.ts
@@ -5,7 +5,7 @@ import globby from 'globby';
 import {getDiagnostics as getTSDiagnostics} from './compiler';
 import loadConfig from './config';
 import getCustomDiagnostics from './rules';
-import {Context, Config, Diagnostic, PackageJsonWithTsdConfig} from './interfaces';
+import {Config, Context, ExtendedDiagnostic, PackageJsonWithTsdConfig} from './interfaces';
 
 export interface Options {
 	cwd: string;
@@ -78,7 +78,7 @@ const findTestFiles = async (typingsFilePath: string, options: Options & {config
  *
  * @returns A promise which resolves the diagnostics of the type definition.
  */
-export default async (options: Options = {cwd: process.cwd()}): Promise<Diagnostic[]> => {
+export default async (options: Options = {cwd: process.cwd()}): Promise<ExtendedDiagnostic> => {
 	const pkgResult = await readPkgUp({cwd: options.cwd});
 
 	if (!pkgResult) {
@@ -104,8 +104,14 @@ export default async (options: Options = {cwd: process.cwd()}): Promise<Diagnost
 		config
 	};
 
-	return [
-		...getCustomDiagnostics(context),
-		...getTSDiagnostics(context)
-	];
+	const {diagnostics: tsDiagnostics, testCount} = getTSDiagnostics(context);
+	const customDiagnostics = getCustomDiagnostics(context);
+
+	return {
+		testCount,
+		diagnostics: [
+			...customDiagnostics,
+			...tsDiagnostics
+		]
+	};
 };

--- a/source/lib/interfaces.ts
+++ b/source/lib/interfaces.ts
@@ -56,6 +56,11 @@ export interface Diagnostic {
 	column?: number;
 }
 
+export interface ExtendedDiagnostic {
+	testCount: number;
+	diagnostics: Diagnostic[];
+}
+
 export interface Location {
 	fileName: string;
 	start: number;

--- a/source/lib/rules/index.ts
+++ b/source/lib/rules/index.ts
@@ -16,7 +16,7 @@ const rules = new Set<RuleFunction>([
  * @param context - The context object.
  * @returns List of diagnostics
  */
-export default (context: Context) => {
+export default (context: Context): Diagnostic[] => {
 	const diagnostics: Diagnostic[] = [];
 
 	for (const rule of rules) {

--- a/source/test/fixtures/utils.ts
+++ b/source/test/fixtures/utils.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import {ExecutionContext} from 'ava';
-import {Diagnostic} from '../../lib/interfaces';
+import {ExtendedDiagnostic} from '../../lib/interfaces';
 
 type Expectation = [
 	line: number,
@@ -21,10 +21,14 @@ type ExpectationWithFileName = [
  * Verify a list of diagnostics.
  *
  * @param t - The AVA execution context.
- * @param diagnostics - List of diagnostics to verify.
+ * @param extendedDiagnostics - Object containing list of TypeScript diagnostics and test count.
  * @param expectations - Expected diagnostics.
  */
-export const verify = (t: ExecutionContext, diagnostics: Diagnostic[], expectations: Expectation[]) => {
+export const verify = (
+	t: ExecutionContext,
+	{diagnostics}: ExtendedDiagnostic,
+	expectations: Expectation[]
+) => {
 	const diagnosticObjs = diagnostics.map(({line, column, severity, message}) => ({
 		line,
 		column,
@@ -47,13 +51,13 @@ export const verify = (t: ExecutionContext, diagnostics: Diagnostic[], expectati
  *
  * @param t - The AVA execution context.
  * @param cwd - The working directory as passed to `tsd`.
- * @param diagnostics - List of diagnostics to verify.
+ * @param extendedDiagnostics - Object containing list of TypeScript diagnostics and test count.
  * @param expectations - Expected diagnostics.
  */
 export const verifyWithFileName = (
 	t: ExecutionContext,
 	cwd: string,
-	diagnostics: Diagnostic[],
+	{diagnostics}: ExtendedDiagnostic,
 	expectations: ExpectationWithFileName[]
 ) => {
 	const diagnosticObjs = diagnostics.map(({line, column, severity, message, fileName}) => ({

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -368,7 +368,7 @@ test('includes extended config files along with found ones', async t => {
 });
 
 test('errors in libs from node_modules are not reported', async t => {
-	const diagnostics = await tsd({cwd: path.join(__dirname, 'fixtures/exclude-node-modules')});
+	const {diagnostics, testCount} = await tsd({cwd: path.join(__dirname, 'fixtures/exclude-node-modules')});
 
 	const [nodeModuleDiagnostics, testFileDiagnostics, otherDiagnostics] = diagnostics.reduce<Diagnostic[][]>(
 		([nodeModuleDiags, testFileDiags, otherDiags], diagnostic) => {
@@ -407,7 +407,7 @@ test('errors in libs from node_modules are not reported', async t => {
 		);
 	});
 
-	verify(t, testFileDiagnostics, [
+	verify(t, {diagnostics: testFileDiagnostics, testCount}, [
 		[3, 18, 'error', 'Cannot find name \'Bar\'.']
 	]);
 });
@@ -430,4 +430,10 @@ test('prints the types of expressions passed to `printType` helper', async t => 
 		[9, 0, 'warning', 'Type for expression `null as unknown` is: `unknown`'],
 		[10, 0, 'warning', 'Type for expression `\'foo\'` is: `"foo"`'],
 	]);
+});
+
+test('checking testCount', async t => {
+	const diagnostics = await tsd({cwd: path.join(__dirname, 'fixtures/failure')});
+
+	t.is(diagnostics.testCount, 2);
 });

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -12,8 +12,10 @@ test('throw if no test is found', async t => {
 	await t.throwsAsync(tsd({cwd: path.join(__dirname, 'fixtures/no-test')}), {message: 'The test file `index.test-d.ts` or `index.test-d.tsx` does not exist. Create one and try again.'});
 });
 
-test('return diagnostics', async t => {
+test('return extended diagnostics object', async t => {
 	const diagnostics = await tsd({cwd: path.join(__dirname, 'fixtures/failure')});
+
+	t.is(diagnostics.testCount, 2, 'Received test count that is different from expected.');
 
 	verify(t, diagnostics, [
 		[5, 19, 'error', 'Argument of type \'number\' is not assignable to parameter of type \'string\'.']
@@ -430,10 +432,4 @@ test('prints the types of expressions passed to `printType` helper', async t => 
 		[9, 0, 'warning', 'Type for expression `null as unknown` is: `unknown`'],
 		[10, 0, 'warning', 'Type for expression `\'foo\'` is: `"foo"`'],
 	]);
-});
-
-test('checking testCount', async t => {
-	const diagnostics = await tsd({cwd: path.join(__dirname, 'fixtures/failure')});
-
-	t.is(diagnostics.testCount, 2);
 });


### PR DESCRIPTION
This is rebased and cleaned up of stale #75.

My motivation is simply to make it possible to use `tsd` with `jest`.

PS I couldn’t find a way to work directly on #75. New PR seemed to be the solution. If this is somehow non-nonethical or a bad practise, I am fine to close and to proceed in some other way.