### PR TITLE
Upgrade TypeScript to 4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"typedefinitions"
 	],
 	"dependencies": {
-		"@tsd/typescript": "~4.4.3",
+		"@tsd/typescript": "~4.5.2",
 		"eslint-formatter-pretty": "^4.1.0",
 		"globby": "^11.0.1",
 		"meow": "^9.0.0",


### PR DESCRIPTION
Hello, thank you very much for your work. It is extremely helpful 🙂

TypeScript 4.5 was released yesterday, so here is a PR to reflect that to tsd.
Notably, [TypeScript 4.5 added a new way to replace built-in type definitions](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#lib-node-modules) and tsd would be very helpful for testing custom type definitions.

Thank you 🙂