### PR TITLE
Make `expectError` support TS2820 error introduced in TypeScript 4.5

### DIFF
--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -37,6 +37,7 @@ const expectErrordiagnosticCodesToIgnore = new Set<DiagnosticCode>([
 	DiagnosticCode.NewExpressionTargetLackingConstructSignatureHasAnyType,
 	DiagnosticCode.MemberCannotHaveOverrideModifierBecauseItIsNotDeclaredInBaseClass,
 	DiagnosticCode.MemberMustHaveOverrideModifier,
+	DiagnosticCode.StringLiteralTypeIsNotAssignableToUnionTypeWithSuggestion,
 ]);
 
 type IgnoreDiagnosticResult = 'preserve' | 'ignore' | Location;

--- a/source/lib/interfaces.ts
+++ b/source/lib/interfaces.ts
@@ -43,6 +43,7 @@ export enum DiagnosticCode {
 	PropertyMissingInType1ButRequiredInType2 = 2741,
 	NoOverloadExpectsCountOfTypeArguments = 2743,
 	NoOverloadMatches = 2769,
+	StringLiteralTypeIsNotAssignableToUnionTypeWithSuggestion = 2820,
 	MemberCannotHaveOverrideModifierBecauseItIsNotDeclaredInBaseClass = 4113,
 	MemberMustHaveOverrideModifier = 4114,
 	NewExpressionTargetLackingConstructSignatureHasAnyType = 7009,

--- a/source/test/fixtures/expect-error/values/index.d.ts
+++ b/source/test/fixtures/expect-error/values/index.d.ts
@@ -18,3 +18,9 @@ export function atLeastOne(...expected: [unknown, ...Array<unknown>]): void;
 export interface Options<T> {}
 
 export class MyClass {}
+
+export const triggerSuggestion: {
+	// fooOrBar must be of union type to trigger TS2820, otherwise TypeScript will
+	// emit a regular TS2322 error without the "Did you mean..." suggestion.
+	fooOrBar: 'foo' | 'bar';
+};

--- a/source/test/fixtures/expect-error/values/index.test-d.ts
+++ b/source/test/fixtures/expect-error/values/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectError} from '../../../..';
-import {default as one, atLeastOne, foo, getFoo, HasKey, hasProperty, MyClass, Options} from '.';
+import {default as one, atLeastOne, foo, getFoo, HasKey, hasProperty, MyClass, Options, triggerSuggestion} from '.';
 
 expectError<string>(1);
 expectError<string>('fo');
@@ -33,3 +33,7 @@ expectError(MyClass());
 
 // 'new' expression, whose target lacks a construct signature, implicitly has an 'any' type.
 expectError(new hasProperty({name: 'foo'}));
+
+expectError(() => {
+	triggerSuggestion.fooOrBar = 'fooo';
+})


### PR DESCRIPTION
Support `Type '{0}' is not assignable to type '{1}'. Did you mean '{2}'?` (TS2820) error for string literal unions.

Fixes: #138
