### PR TITLE
Add support for nodenext moduleResolution

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -135,7 +135,8 @@ By default, `tsd` applies the following configuration:
 	"target": "es2017",
 	"lib": ["es2017"],
 	"module": "commonjs",
-	// The following option is set and is not overridable:
+	// The following option is set and is not overridable.
+	// It is set to `nodenext` if `module` is `nodenext`, `node16` if `module` is `node16` or `node` otherwise.
 	"moduleResolution": "node" | "node16" | "nodenext"
 }
 ```
@@ -153,7 +154,7 @@ These options will be overridden if a `tsconfig.json` file is found in your proj
 }
 ```
 
-*Default options will apply if you don't override them explicitly.* You can't override the `moduleResolution` option. `moduleResolution` is set to `nodenext` if `module` is `nodenext`, `node16` if `module` is `node16` or `node` otherwise.
+*Default options will apply if you don't override them explicitly.* You can't override the `moduleResolution` option. 
 
 ## Assertions
 

--- a/readme.md
+++ b/readme.md
@@ -136,7 +136,7 @@ By default, `tsd` applies the following configuration:
 	"lib": ["es2017"],
 	"module": "commonjs",
 	// The following option is set and is not overridable:
-	"moduleResolution": "node"
+	"moduleResolution": "node" | "node16" | "nodenext"
 }
 ```
 
@@ -153,7 +153,7 @@ These options will be overridden if a `tsconfig.json` file is found in your proj
 }
 ```
 
-*Default options will apply if you don't override them explicitly.* You can't override the `moduleResolution` option.
+*Default options will apply if you don't override them explicitly.* You can't override the `moduleResolution` option. `moduleResolution` is set to `nodenext` if `module` is `nodenext`, `node16` if `module` is `node16` or `node` otherwise.
 
 ## Assertions
 

--- a/source/lib/config.ts
+++ b/source/lib/config.ts
@@ -27,6 +27,11 @@ export default (pkg: PackageJsonWithTsdConfig, cwd: string): Config => {
 		cwd
 	);
 
+	const combinedCompilerOptions = {
+		...tsConfigCompilerOptions,
+		...packageJsonCompilerOptions,
+	};
+
 	return {
 		directory: 'test-d',
 		...pkgConfig,
@@ -37,9 +42,14 @@ export default (pkg: PackageJsonWithTsdConfig, cwd: string): Config => {
 			module: ModuleKind.CommonJS,
 			target: ScriptTarget.ES2017,
 			esModuleInterop: true,
-			...tsConfigCompilerOptions,
-			...packageJsonCompilerOptions,
-			moduleResolution: ModuleResolutionKind.NodeJs,
+			...combinedCompilerOptions,
+			moduleResolution: combinedCompilerOptions.module === undefined ?
+				ModuleResolutionKind.NodeJs :
+				combinedCompilerOptions.module === ModuleKind.NodeNext ?
+					ModuleResolutionKind.NodeNext :
+					combinedCompilerOptions.module === ModuleKind.Node16 ?
+						ModuleResolutionKind.Node16 :
+						ModuleResolutionKind.NodeJs,
 			skipLibCheck: false
 		}
 	};

--- a/source/lib/config.ts
+++ b/source/lib/config.ts
@@ -45,9 +45,9 @@ export default (pkg: PackageJsonWithTsdConfig, cwd: string): Config => {
 			target: ScriptTarget.ES2017,
 			esModuleInterop: true,
 			...combinedCompilerOptions,
-			moduleResolution: combinedCompilerOptions.module === ModuleKind.NodeNext ?
+			moduleResolution: module === ModuleKind.NodeNext ?
 				ModuleResolutionKind.NodeNext :
-				combinedCompilerOptions.module === ModuleKind.Node16 ?
+				module === ModuleKind.Node16 ?
 					ModuleResolutionKind.Node16 :
 					ModuleResolutionKind.NodeJs,
 			skipLibCheck: false

--- a/source/lib/config.ts
+++ b/source/lib/config.ts
@@ -32,6 +32,8 @@ export default (pkg: PackageJsonWithTsdConfig, cwd: string): Config => {
 		...packageJsonCompilerOptions,
 	};
 
+	const module = combinedCompilerOptions.module ?? ModuleKind.CommonJS;
+
 	return {
 		directory: 'test-d',
 		...pkgConfig,
@@ -39,17 +41,15 @@ export default (pkg: PackageJsonWithTsdConfig, cwd: string): Config => {
 			strict: true,
 			jsx: JsxEmit.React,
 			lib: parseRawLibs(['es2017', 'dom', 'dom.iterable'], cwd),
-			module: ModuleKind.CommonJS,
+			module,
 			target: ScriptTarget.ES2017,
 			esModuleInterop: true,
 			...combinedCompilerOptions,
-			moduleResolution: combinedCompilerOptions.module === undefined ?
-				ModuleResolutionKind.NodeJs :
-				combinedCompilerOptions.module === ModuleKind.NodeNext ?
-					ModuleResolutionKind.NodeNext :
-					combinedCompilerOptions.module === ModuleKind.Node16 ?
-						ModuleResolutionKind.Node16 :
-						ModuleResolutionKind.NodeJs,
+			moduleResolution: combinedCompilerOptions.module === ModuleKind.NodeNext ?
+				ModuleResolutionKind.NodeNext :
+				combinedCompilerOptions.module === ModuleKind.Node16 ?
+					ModuleResolutionKind.Node16 :
+					ModuleResolutionKind.NodeJs,
 			skipLibCheck: false
 		}
 	};

--- a/source/test/fixtures/module-resolution/node16-from-package-json/index.d.ts
+++ b/source/test/fixtures/module-resolution/node16-from-package-json/index.d.ts
@@ -1,0 +1,3 @@
+declare const foo: string;
+
+export default foo;

--- a/source/test/fixtures/module-resolution/node16-from-package-json/index.js
+++ b/source/test/fixtures/module-resolution/node16-from-package-json/index.js
@@ -1,0 +1,1 @@
+module.exports.default = "foo";

--- a/source/test/fixtures/module-resolution/node16-from-package-json/index.js
+++ b/source/test/fixtures/module-resolution/node16-from-package-json/index.js
@@ -1,1 +1,1 @@
-module.exports.default = "foo";
+module.exports.default = 'foo';

--- a/source/test/fixtures/module-resolution/node16-from-package-json/index.test-d.ts
+++ b/source/test/fixtures/module-resolution/node16-from-package-json/index.test-d.ts
@@ -1,4 +1,4 @@
 import foo from 'foo';
-import {expectType} from '../../../..';
+import {expectType} from '../../../../index.js';
 
 expectType<string>(foo);

--- a/source/test/fixtures/module-resolution/node16-from-package-json/index.test-d.ts
+++ b/source/test/fixtures/module-resolution/node16-from-package-json/index.test-d.ts
@@ -1,4 +1,4 @@
-import foo from "foo";
+import foo from 'foo';
 import {expectType} from '../../../..';
 
 expectType<string>(foo);

--- a/source/test/fixtures/module-resolution/node16-from-package-json/index.test-d.ts
+++ b/source/test/fixtures/module-resolution/node16-from-package-json/index.test-d.ts
@@ -1,0 +1,4 @@
+import foo from "foo";
+import {expectType} from '../../../..';
+
+expectType<string>(foo);

--- a/source/test/fixtures/module-resolution/node16-from-package-json/package.json
+++ b/source/test/fixtures/module-resolution/node16-from-package-json/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "foo",
+	"type": "module",
 	"exports": "./index.js",
 	"tsd": {
 		"compilerOptions": {

--- a/source/test/fixtures/module-resolution/node16-from-package-json/package.json
+++ b/source/test/fixtures/module-resolution/node16-from-package-json/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "foo",
+	"exports": "./index.js",
+	"tsd": {
+		"compilerOptions": {
+			"module": "node16"
+		}
+	}
+}

--- a/source/test/fixtures/module-resolution/node16-from-tsconfig-json/index.d.ts
+++ b/source/test/fixtures/module-resolution/node16-from-tsconfig-json/index.d.ts
@@ -1,0 +1,3 @@
+declare const foo: string;
+
+export default foo;

--- a/source/test/fixtures/module-resolution/node16-from-tsconfig-json/index.js
+++ b/source/test/fixtures/module-resolution/node16-from-tsconfig-json/index.js
@@ -1,0 +1,1 @@
+module.exports.default = "foo";

--- a/source/test/fixtures/module-resolution/node16-from-tsconfig-json/index.js
+++ b/source/test/fixtures/module-resolution/node16-from-tsconfig-json/index.js
@@ -1,1 +1,1 @@
-module.exports.default = "foo";
+module.exports.default = 'foo';

--- a/source/test/fixtures/module-resolution/node16-from-tsconfig-json/index.test-d.ts
+++ b/source/test/fixtures/module-resolution/node16-from-tsconfig-json/index.test-d.ts
@@ -1,4 +1,4 @@
 import foo from 'foo';
-import {expectType} from '../../../..';
+import {expectType} from '../../../../index.js';
 
 expectType<string>(foo);

--- a/source/test/fixtures/module-resolution/node16-from-tsconfig-json/index.test-d.ts
+++ b/source/test/fixtures/module-resolution/node16-from-tsconfig-json/index.test-d.ts
@@ -1,4 +1,4 @@
-import foo from "foo";
+import foo from 'foo';
 import {expectType} from '../../../..';
 
 expectType<string>(foo);

--- a/source/test/fixtures/module-resolution/node16-from-tsconfig-json/index.test-d.ts
+++ b/source/test/fixtures/module-resolution/node16-from-tsconfig-json/index.test-d.ts
@@ -1,0 +1,4 @@
+import foo from "foo";
+import {expectType} from '../../../..';
+
+expectType<string>(foo);

--- a/source/test/fixtures/module-resolution/node16-from-tsconfig-json/package.json
+++ b/source/test/fixtures/module-resolution/node16-from-tsconfig-json/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "foo",
+	"exports": "./index.js"
+}

--- a/source/test/fixtures/module-resolution/node16-from-tsconfig-json/package.json
+++ b/source/test/fixtures/module-resolution/node16-from-tsconfig-json/package.json
@@ -1,4 +1,5 @@
 {
 	"name": "foo",
+	"type": "module",
 	"exports": "./index.js"
 }

--- a/source/test/fixtures/module-resolution/node16-from-tsconfig-json/tsconfig.json
+++ b/source/test/fixtures/module-resolution/node16-from-tsconfig-json/tsconfig.json
@@ -1,0 +1,5 @@
+{
+	"compilerOptions": {
+		"module": "node16"
+	}
+}

--- a/source/test/fixtures/module-resolution/nodenext-from-package-json/index.d.ts
+++ b/source/test/fixtures/module-resolution/nodenext-from-package-json/index.d.ts
@@ -1,0 +1,3 @@
+declare const foo: string;
+
+export default foo;

--- a/source/test/fixtures/module-resolution/nodenext-from-package-json/index.js
+++ b/source/test/fixtures/module-resolution/nodenext-from-package-json/index.js
@@ -1,0 +1,1 @@
+module.exports.default = "foo";

--- a/source/test/fixtures/module-resolution/nodenext-from-package-json/index.js
+++ b/source/test/fixtures/module-resolution/nodenext-from-package-json/index.js
@@ -1,1 +1,1 @@
-module.exports.default = "foo";
+module.exports.default = 'foo';

--- a/source/test/fixtures/module-resolution/nodenext-from-package-json/index.test-d.ts
+++ b/source/test/fixtures/module-resolution/nodenext-from-package-json/index.test-d.ts
@@ -1,4 +1,4 @@
 import foo from 'foo';
-import {expectType} from '../../../..';
+import {expectType} from '../../../../index.js';
 
 expectType<string>(foo);

--- a/source/test/fixtures/module-resolution/nodenext-from-package-json/index.test-d.ts
+++ b/source/test/fixtures/module-resolution/nodenext-from-package-json/index.test-d.ts
@@ -1,4 +1,4 @@
-import foo from "foo";
+import foo from 'foo';
 import {expectType} from '../../../..';
 
 expectType<string>(foo);

--- a/source/test/fixtures/module-resolution/nodenext-from-package-json/index.test-d.ts
+++ b/source/test/fixtures/module-resolution/nodenext-from-package-json/index.test-d.ts
@@ -1,0 +1,4 @@
+import foo from "foo";
+import {expectType} from '../../../..';
+
+expectType<string>(foo);

--- a/source/test/fixtures/module-resolution/nodenext-from-package-json/package.json
+++ b/source/test/fixtures/module-resolution/nodenext-from-package-json/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "foo",
+	"exports": "./index.js",
+	"tsd": {
+		"compilerOptions": {
+			"module": "nodenext"
+		}
+	}
+}

--- a/source/test/fixtures/module-resolution/nodenext-from-package-json/package.json
+++ b/source/test/fixtures/module-resolution/nodenext-from-package-json/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "foo",
+	"type": "module",
 	"exports": "./index.js",
 	"tsd": {
 		"compilerOptions": {

--- a/source/test/fixtures/module-resolution/nodenext-from-tsconfig-json/index.d.ts
+++ b/source/test/fixtures/module-resolution/nodenext-from-tsconfig-json/index.d.ts
@@ -1,0 +1,3 @@
+declare const foo: string;
+
+export default foo;

--- a/source/test/fixtures/module-resolution/nodenext-from-tsconfig-json/index.js
+++ b/source/test/fixtures/module-resolution/nodenext-from-tsconfig-json/index.js
@@ -1,0 +1,1 @@
+module.exports.default = "foo";

--- a/source/test/fixtures/module-resolution/nodenext-from-tsconfig-json/index.js
+++ b/source/test/fixtures/module-resolution/nodenext-from-tsconfig-json/index.js
@@ -1,1 +1,1 @@
-module.exports.default = "foo";
+module.exports.default = 'foo';

--- a/source/test/fixtures/module-resolution/nodenext-from-tsconfig-json/index.test-d.ts
+++ b/source/test/fixtures/module-resolution/nodenext-from-tsconfig-json/index.test-d.ts
@@ -1,4 +1,4 @@
 import foo from 'foo';
-import {expectType} from '../../../..';
+import {expectType} from '../../../../index.js';
 
 expectType<string>(foo);

--- a/source/test/fixtures/module-resolution/nodenext-from-tsconfig-json/index.test-d.ts
+++ b/source/test/fixtures/module-resolution/nodenext-from-tsconfig-json/index.test-d.ts
@@ -1,4 +1,4 @@
-import foo from "foo";
+import foo from 'foo';
 import {expectType} from '../../../..';
 
 expectType<string>(foo);

--- a/source/test/fixtures/module-resolution/nodenext-from-tsconfig-json/index.test-d.ts
+++ b/source/test/fixtures/module-resolution/nodenext-from-tsconfig-json/index.test-d.ts
@@ -1,0 +1,4 @@
+import foo from "foo";
+import {expectType} from '../../../..';
+
+expectType<string>(foo);

--- a/source/test/fixtures/module-resolution/nodenext-from-tsconfig-json/package.json
+++ b/source/test/fixtures/module-resolution/nodenext-from-tsconfig-json/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "foo",
+	"exports": "./index.js"
+}

--- a/source/test/fixtures/module-resolution/nodenext-from-tsconfig-json/package.json
+++ b/source/test/fixtures/module-resolution/nodenext-from-tsconfig-json/package.json
@@ -1,4 +1,5 @@
 {
 	"name": "foo",
+	"type": "module",
 	"exports": "./index.js"
 }

--- a/source/test/fixtures/module-resolution/nodenext-from-tsconfig-json/tsconfig.json
+++ b/source/test/fixtures/module-resolution/nodenext-from-tsconfig-json/tsconfig.json
@@ -1,0 +1,5 @@
+{
+	"compilerOptions": {
+		"module": "nodenext"
+	}
+}

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -138,25 +138,25 @@ test('allow specifying a lib in tsconfig.json', async t => {
 	verify(t, diagnostics, []);
 });
 
-test('use moduleResolution NodeNext when module is nodenext in tsconfig.json', async t => {
+test('use moduleResolution `nodenext` when module is `nodenext` in tsconfig.json', async t => {
 	const diagnostics = await tsd({cwd: path.join(__dirname, 'fixtures/module-resolution/nodenext-from-tsconfig-json')});
 
 	verify(t, diagnostics, []);
 });
 
-test('use moduleResolution NodeNext when module is nodenext in package.json', async t => {
+test('use moduleResolution `nodenext` when module is `nodenext` in package.json', async t => {
 	const diagnostics = await tsd({cwd: path.join(__dirname, 'fixtures/module-resolution/nodenext-from-package-json')});
 
 	verify(t, diagnostics, []);
 });
 
-test('use moduleResolution Node16 when module is node16 in tsconfig.json', async t => {
+test('use moduleResolution `node16` when module is `node16` in tsconfig.json', async t => {
 	const diagnostics = await tsd({cwd: path.join(__dirname, 'fixtures/module-resolution/node16-from-tsconfig-json')});
 
 	verify(t, diagnostics, []);
 });
 
-test('use moduleResolution Node16 when module is node16 in package.json', async t => {
+test('use moduleResolution `node16` when module is `node16` in package.json', async t => {
 	const diagnostics = await tsd({cwd: path.join(__dirname, 'fixtures/module-resolution/node16-from-package-json')});
 
 	verify(t, diagnostics, []);

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -138,6 +138,30 @@ test('allow specifying a lib in tsconfig.json', async t => {
 	verify(t, diagnostics, []);
 });
 
+test('use moduleResolution NodeNext when module is nodenext in tsconfig.json', async t => {
+	const diagnostics = await tsd({cwd: path.join(__dirname, 'fixtures/module-resolution/nodenext-from-tsconfig-json')});
+
+	verify(t, diagnostics, []);
+});
+
+test('use moduleResolution NodeNext when module is nodenext in package.json', async t => {
+	const diagnostics = await tsd({cwd: path.join(__dirname, 'fixtures/module-resolution/nodenext-from-package-json')});
+
+	verify(t, diagnostics, []);
+});
+
+test('use moduleResolution Node16 when module is node16 in tsconfig.json', async t => {
+	const diagnostics = await tsd({cwd: path.join(__dirname, 'fixtures/module-resolution/node16-from-tsconfig-json')});
+
+	verify(t, diagnostics, []);
+});
+
+test('use moduleResolution Node16 when module is node16 in package.json', async t => {
+	const diagnostics = await tsd({cwd: path.join(__dirname, 'fixtures/module-resolution/node16-from-package-json')});
+
+	verify(t, diagnostics, []);
+});
+
 test('add support for esm with esModuleInterop', async t => {
 	const diagnostics = await tsd({
 		cwd: path.join(__dirname, 'fixtures/esm')


### PR DESCRIPTION
Edit: Sorry, failed to leave a description!
This change aims to set the `moduleResolution` to `nodenext` or `node16` when appropriate.
This allows for using `nodenext` features inside `tsd` test files, such as `self-module imports`, which I have tested here.
This is the feature that I am missing to incorporate `tsd` in https://github.com/dotcore64/p-from-callback/pull/15
Thanks!