### PR TITLE
README fix - `--typings`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -245,8 +245,6 @@ The `tsd` CLI is designed to test a whole project at once, and as such only offe
 
 #### --typings
 
-Asserts that the type of `expression` is identical to type `T`.
-
 Alias: `-t`
 
 Path to the type definition file you want to test. Same as [`typingsFile`](#typingsfile).

--- a/readme.md
+++ b/readme.md
@@ -243,6 +243,8 @@ These options will be overridden if a `tsconfig.json` file is found in your proj
 
 The `tsd` CLI is designed to test a whole project at once, and as such only offers a couple of flags for configuration.
 
+#### --typings
+
 Asserts that the type of `expression` is identical to type `T`.
 
 Alias: `-t`


### PR DESCRIPTION
At some point along the way of merging in #156, the `--typings` heading got lost:

https://github.com/SamVerschueren/tsd/blob/b777588a19b01e8a0e861c32164231d9f06e278d/readme.md?plain=1#L242-L256

This PR adds it back.