### PR TITLE
fix(`DiagnosticCode`): add `ts(2707)`

### DIFF
--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -22,6 +22,7 @@ const expectErrordiagnosticCodesToIgnore = new Set<DiagnosticCode>([
 	DiagnosticCode.TypeIsNotAssignableToOtherType,
 	DiagnosticCode.TypeDoesNotSatisfyTheConstraint,
 	DiagnosticCode.GenericTypeRequiresTypeArguments,
+	DiagnosticCode.GenericTypeRequiresBetweenXAndYTypeArugments,
 	DiagnosticCode.ExpectedArgumentsButGotOther,
 	DiagnosticCode.ExpectedAtLeastArgumentsButGotOther,
 	DiagnosticCode.NoOverloadExpectsCountOfArguments,

--- a/source/lib/interfaces.ts
+++ b/source/lib/interfaces.ts
@@ -26,6 +26,7 @@ export enum DiagnosticCode {
 	AwaitExpressionOnlyAllowedWithinAsyncFunction = 1308,
 	TopLevelAwaitOnlyAllowedWhenModuleESNextOrSystem = 1378,
 	GenericTypeRequiresTypeArguments = 2314,
+	GenericTypeRequiresBetweenXAndYTypeArugments = 2707,
 	TypeIsNotAssignableToOtherType = 2322,
 	TypeDoesNotSatisfyTheConstraint = 2344,
 	PropertyDoesNotExistOnType = 2339,

--- a/source/test/fixtures/expect-error/generics/index.d.ts
+++ b/source/test/fixtures/expect-error/generics/index.d.ts
@@ -6,3 +6,5 @@ export default one;
 
 export function two<T1>(foo: T1): T1;
 export function two<T1, T2, T3 extends T2>(foo: T1, bar: T2): T3;
+
+export type Three<T1, T2 = 2, T3 = 3> = [T1, T2, T3];

--- a/source/test/fixtures/expect-error/generics/index.test-d.ts
+++ b/source/test/fixtures/expect-error/generics/index.test-d.ts
@@ -1,8 +1,10 @@
-import {expectError} from '../../../..';
-import one, {two} from '.';
+import {expectError, expectType} from '../../../..';
+import one, {two, type Three} from '.';
 
 expectError(one(true, true));
 
 expectError(one<number>(1, 2));
 
 expectError(two<number, string>(1, 'bar'));
+
+expectError<Three>('');

--- a/source/test/fixtures/expect-error/generics/index.test-d.ts
+++ b/source/test/fixtures/expect-error/generics/index.test-d.ts
@@ -1,4 +1,4 @@
-import {expectError, expectType} from '../../../..';
+import {expectError} from '../../../..';
 import one, {two, type Three} from '.';
 
 expectError(one(true, true));


### PR DESCRIPTION
Adds a `DiagnosticCode` to check for TS error `2707`, [`"Generic type '${0}' requires between ${1} and ${2} type arguments."`](https://github.com/microsoft/TypeScript/blob/43cc362cef72e5fa1372f59736a9c4b55d85def0/src/compiler/diagnosticMessages.json#L3094-L3097). Came up while trying to add a test for type-fest.