### PR TITLE
feat(`cli`): log stacktrace on failure

### DIFF
--- a/source/cli.ts
+++ b/source/cli.ts
@@ -54,8 +54,15 @@ const cli = meow(`
 			throw new Error(formatter(diagnostics));
 		}
 	} catch (error: unknown) {
-		if (error && typeof (error as Error).message === 'string') {
-			console.error((error as Error).message);
+		const potentialError = error as Error | undefined | null;
+		const errorMessage =
+			typeof potentialError?.stack === 'string' ?
+				potentialError.stack :
+				typeof potentialError?.message === 'string' ?
+					potentialError?.message :
+					undefined;
+		if (errorMessage) {
+			console.error(`Error running tsd: ${errorMessage}`);
 		}
 
 		process.exit(1);

--- a/source/cli.ts
+++ b/source/cli.ts
@@ -54,13 +54,9 @@ const cli = meow(`
 			throw new Error(formatter(diagnostics));
 		}
 	} catch (error: unknown) {
-		const potentialError = error as Error | undefined | null;
-		const errorMessage =
-			typeof potentialError?.stack === 'string' ?
-				potentialError.stack :
-				typeof potentialError?.message === 'string' ?
-					potentialError?.message :
-					undefined;
+		const potentialError = error as Error | undefined;
+		const errorMessage = potentialError?.stack ?? potentialError?.message;
+
 		if (errorMessage) {
 			console.error(`Error running tsd: ${errorMessage}`);
 		}

--- a/source/test/cli.ts
+++ b/source/test/cli.ts
@@ -95,3 +95,13 @@ test('cli typings and files flags', async t => {
 	t.is(exitCode, 1);
 	t.true(stderr.includes('✖  5:19  Argument of type number is not assignable to parameter of type string.'));
 });
+
+test('tsd logs stacktrace on failure', async t => {
+	const {exitCode, stderr, stack} = await t.throwsAsync<ExecaError>(execa('../../../cli.js', {
+		cwd: path.join(__dirname, 'fixtures/empty-package-json')
+	}));
+
+	t.is(exitCode, 1);
+	t.true(stderr.includes('Error running tsd: JSONError: Unexpected end of JSON input while parsing empty string'));
+	t.truthy(stack);
+});


### PR DESCRIPTION
Continued from #152. Closes #137.

Implements requested changes from stale PR and adds a test case.

Closes #152