### PR TITLE
Export formatter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -268,6 +268,14 @@ console.log(diagnostics.length);
 //=> 2
 ```
 
+You can also make use of the CLI's formatter to generate the same formatting output when running `tsd` programmatically.
+
+```ts
+import tsd, {formatter} from 'tsd';
+
+const formattedDiagnostics = formatter(await tsd());
+```
+
 ### tsd(options?)
 
 Retrieve the type definition diagnostics of the project.

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,4 +1,6 @@
 import tsd from './lib';
+import formatter from './lib/formatter';
 
 export * from './lib/assertions/assert';
+export {formatter};
 export default tsd;

--- a/source/test/cli.ts
+++ b/source/test/cli.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import test from 'ava';
 import execa from 'execa';
 import readPkgUp from 'read-pkg-up';
+import tsd, {formatter} from '..';
 
 interface ExecaError extends Error {
 	readonly exitCode: number;
@@ -104,4 +105,19 @@ test('tsd logs stacktrace on failure', async t => {
 	t.is(exitCode, 1);
 	t.true(stderr.includes('Error running tsd: JSONError: Unexpected end of JSON input while parsing empty string'));
 	t.truthy(stack);
+});
+
+test('exported formatter matches tsd results', async t => {
+	const options = {
+		cwd: path.join(__dirname, 'fixtures/failure'),
+	};
+
+	const {stderr: cliResults} = await t.throwsAsync<ExecaError>(execa('../../../cli.js', options));
+
+	t.true(cliResults.includes('✖  5:19  Argument of type number is not assignable to parameter of type string.'));
+
+	const tsdResults = await tsd(options);
+	const formattedResults = formatter(tsdResults);
+
+	t.true(formattedResults.includes('✖  5:19  Argument of type number is not assignable to parameter of type string.'));
 });

--- a/source/test/cli.ts
+++ b/source/test/cli.ts
@@ -107,7 +107,7 @@ test('tsd logs stacktrace on failure', async t => {
 	t.truthy(stack);
 });
 
-test('exported formatter matches tsd results', async t => {
+test('exported formatter matches cli results', async t => {
 	const options = {
 		cwd: path.join(__dirname, 'fixtures/failure'),
 	};


### PR DESCRIPTION
Closes #147.

With #165 changing the formatter, it makes more sense to provide our formatter so that programmatic users can prettify their output, too.

`tsd` is still the default export, but the formatter can be imported like so:

```ts
import tsd, {formatter} from 'tsd';
```