### PR TITLE
Allow testing string sources

### DIFF
--- a/source/cli.ts
+++ b/source/cli.ts
@@ -15,12 +15,14 @@ const cli = meow(`
 
 	Options
 	  --typings  -t  Type definition file to test  [Default: "types" property in package.json]
-	  --files    -f  Glob of files to test         [Default: '/path/test-d/**/*.test-d.ts' or '.tsx']
+	  --files    -f  Glob or source files to test  [Default: '/path/test-d/**/*.test-d.ts' or '.tsx']
 
 	Examples
 	  $ tsd /path/to/project
 
 	  $ tsd --files /test/some/folder/*.ts --files /test/other/folder/*.tsx
+
+	  $ tsc foo.ts --module 'none' --outFile '/dev/stdout' | xargs -I{} tsd --files "foo.js:{}"
 
 	  $ tsd
 
@@ -43,12 +45,9 @@ const cli = meow(`
 (async () => {
 	try {
 		const cwd = cli.input.length > 0 ? cli.input[0] : process.cwd();
-		const typingsFile = cli.flags.typings;
-		const testFiles = cli.flags.files;
+		const {typings: typingsFile, files: testFiles} = cli.flags;
 
-		const options = {cwd, typingsFile, testFiles};
-
-		const diagnostics = await tsd(options);
+		const diagnostics = await tsd({cwd, typingsFile, testFiles});
 
 		if (diagnostics.length > 0) {
 			throw new Error(formatter(diagnostics));

--- a/source/lib/interfaces.ts
+++ b/source/lib/interfaces.ts
@@ -14,11 +14,23 @@ export type PackageJsonWithTsdConfig = NormalizedPackageJson & {
 	tsd?: RawConfig;
 };
 
+export type TestFiles = ReadonlyArray<(
+	| string
+	| {name: string; text: string}
+)>;
+
+export type SourceFiles = ReadonlyArray<{name: string; text: string}>;
+
+export type ParsedTestFiles = {
+	globs: readonly string[];
+	sourceFiles?: SourceFiles;
+};
+
 export interface Context {
 	cwd: string;
 	pkg: PackageJsonWithTsdConfig;
 	typingsFile: string;
-	testFiles: string[];
+	testFiles: ParsedTestFiles;
 	config: Config;
 }
 

--- a/source/lib/utils/filter-test-files.ts
+++ b/source/lib/utils/filter-test-files.ts
@@ -1,0 +1,22 @@
+import type {TestFiles} from '../interfaces';
+
+// https://regex101.com/r/8JO8Wb/1
+const regex = /^(?<name>[^\s:]+\.[^\s:]+):(?<text>.*)$/s;
+
+export const getGlobTestFiles = (testFilesPattern: TestFiles) => {
+	return testFilesPattern.filter(file => typeof file === 'string' && !regex.test(file)) as readonly string[];
+};
+
+export const getTextTestFiles = (testFilesPattern: TestFiles) => {
+	return [
+		...(testFilesPattern
+			.filter(file => typeof file !== 'string')
+		),
+		...(testFilesPattern
+			.filter(file => typeof file === 'string')
+			.map(file => regex.exec(file as string))
+			.filter(Boolean)
+			.map(match => ({name: match?.groups?.name, text: match?.groups?.text}))
+		),
+	] as ReadonlyArray<{name: string; text: string}>;
+};

--- a/source/test/cli.ts
+++ b/source/test/cli.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import test from 'ava';
 import execa from 'execa';
 import readPkgUp from 'read-pkg-up';
@@ -14,7 +14,7 @@ test('fail if errors are found', async t => {
 	}));
 
 	t.is(exitCode, 1);
-	t.regex(stderr, /5:19[ ]{2}Argument of type number is not assignable to parameter of type string./);
+	t.true(stderr.includes('✖  5:19  Argument of type number is not assignable to parameter of type string.'));
 });
 
 test('succeed if no errors are found', async t => {
@@ -31,7 +31,7 @@ test('provide a path', async t => {
 	const {exitCode, stderr} = await t.throwsAsync<ExecaError>(execa('dist/cli.js', [file]));
 
 	t.is(exitCode, 1);
-	t.regex(stderr, /5:19[ ]{2}Argument of type number is not assignable to parameter of type string./);
+	t.true(stderr.includes('✖  5:19  Argument of type number is not assignable to parameter of type string.'));
 });
 
 test('cli help flag', async t => {
@@ -51,9 +51,11 @@ test('cli version flag', async t => {
 
 test('cli typings flag', async t => {
 	const runTest = async (arg: '--typings' | '-t') => {
-		const {exitCode, stderr} = await t.throwsAsync<ExecaError>(execa('../../../cli.js', [arg, 'utils/index.d.ts'], {
-			cwd: path.join(__dirname, 'fixtures/typings-custom-dir')
-		}));
+		const {exitCode, stderr} = await t.throwsAsync<ExecaError>(
+			execa('../../../cli.js', [arg, 'utils/index.d.ts'], {
+				cwd: path.join(__dirname, 'fixtures/typings-custom-dir')
+			})
+		);
 
 		t.is(exitCode, 1);
 		t.true(stderr.includes('✖  5:19  Argument of type number is not assignable to parameter of type string.'));
@@ -65,9 +67,11 @@ test('cli typings flag', async t => {
 
 test('cli files flag', async t => {
 	const runTest = async (arg: '--files' | '-f') => {
-		const {exitCode, stderr} = await t.throwsAsync<ExecaError>(execa('../../../cli.js', [arg, 'unknown.test.ts'], {
-			cwd: path.join(__dirname, 'fixtures/specify-test-files')
-		}));
+		const {exitCode, stderr} = await t.throwsAsync<ExecaError>(
+			execa('../../../cli.js', [arg, 'unknown.test.ts'], {
+				cwd: path.join(__dirname, 'fixtures/specify-test-files')
+			})
+		);
 
 		t.is(exitCode, 1);
 		t.true(stderr.includes('✖  5:19  Argument of type number is not assignable to parameter of type string.'));
@@ -78,9 +82,11 @@ test('cli files flag', async t => {
 });
 
 test('cli files flag array', async t => {
-	const {exitCode, stderr} = await t.throwsAsync<ExecaError>(execa('../../../cli.js', ['--files', 'unknown.test.ts', '--files', 'second.test.ts'], {
-		cwd: path.join(__dirname, 'fixtures/specify-test-files')
-	}));
+	const {exitCode, stderr} = await t.throwsAsync<ExecaError>(
+		execa('../../../cli.js', ['--files', 'unknown.test.ts', '--files', 'second.test.ts'], {
+			cwd: path.join(__dirname, 'fixtures/specify-test-files')
+		})
+	);
 
 	t.is(exitCode, 1);
 	t.true(stderr.includes('✖  5:19  Argument of type number is not assignable to parameter of type string.'));

--- a/source/test/fixtures/files-js/index.d.ts
+++ b/source/test/fixtures/files-js/index.d.ts
@@ -1,0 +1,9 @@
+export type Foo = {
+	a: number;
+	b: string;
+};
+
+export type Bar = {
+	a: string;
+	b: number;
+};

--- a/source/test/fixtures/files-js/index.test-d.js
+++ b/source/test/fixtures/files-js/index.test-d.js
@@ -1,0 +1,17 @@
+import {expectType, expectError} from '../../..';
+
+/** @type {import('.').Foo} */
+let foo = {
+	a: 1,
+	b: '2',
+};
+
+expectType(foo);
+
+expectError(foo = {
+	a: '1',
+	b: 2,
+});
+
+// '')' expected.'
+expectError(;

--- a/source/test/fixtures/files-js/package.json
+++ b/source/test/fixtures/files-js/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "foo",
+	"tsd": {
+		"compilerOptions": {
+			"checkJs": true
+		}
+	}
+}

--- a/source/test/fixtures/specify-test-files/syntax.test.ts
+++ b/source/test/fixtures/specify-test-files/syntax.test.ts
@@ -1,0 +1,1 @@
+const num: number = '1';

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -427,3 +427,14 @@ test('parsing undefined symbol should not fail', async t => {
 
 	verify(t, diagnostics, []);
 });
+
+test('test js files', async t => {
+	const diagnostics = await tsd({
+		cwd: path.join(__dirname, 'fixtures/files-js'),
+		testFiles: ['index.test-d.js']
+	});
+
+	verify(t, diagnostics, [
+		[17, 12, 'error', '\')\' expected.']
+	]);
+});

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -1,4 +1,5 @@
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import test from 'ava';
 import {verify, verifyWithFileName} from './fixtures/utils';
 import tsd from '..';
@@ -436,5 +437,40 @@ test('test js files', async t => {
 
 	verify(t, diagnostics, [
 		[17, 12, 'error', '\')\' expected.']
+	]);
+});
+
+test('test string files', async t => {
+	const diagnostics = await tsd({
+		cwd: path.join(__dirname, 'fixtures/specify-test-files'),
+		testFiles: [
+			{
+				name: 'syntax.test.ts',
+				text: await fs.promises.readFile(path.join(__dirname, 'fixtures/specify-test-files/syntax.test.ts'), 'utf8'),
+			},
+		],
+	});
+
+	verify(t, diagnostics, [
+		[1, 6, 'error', 'Type \'string\' is not assignable to type \'number\'.']
+	]);
+});
+
+test('test string files with glob files', async t => {
+	const diagnostics = await tsd({
+		cwd: path.join(__dirname, 'fixtures/specify-test-files'),
+		testFiles: [
+			'unknown.test.ts',
+			'second.test.ts',
+			{
+				name: 'syntax.test.ts',
+				text: await fs.promises.readFile(path.join(__dirname, 'fixtures/specify-test-files/syntax.test.ts'), 'utf8'),
+			},
+		],
+	});
+
+	verify(t, diagnostics, [
+		[5, 19, 'error', 'Argument of type \'number\' is not assignable to parameter of type \'string\'.'],
+		[1, 6, 'error', 'Type \'string\' is not assignable to type \'number\'.']
 	]);
 });


### PR DESCRIPTION
Closes #86.

Allows testing files passed to `tsd` as strings, either programmatically:

```ts
import tsd from 'tsd';

const diagnostics = await tsd({
	testFiles: [
		'file1.ts',
		{
			'name': 'file2.ts',
			'text': 'import {expectType} from \'tsd\';\nexpectType<number>(1);',
		},
	],
});
```

or via the CLI with a concise syntax (`file.extension:source`):

```sh
$ npx tsd --files "foo.ts:$(cat output.txt)"
```

Type definitions have been updated like so:

```ts
type TestFiles = ReadonlyArray<(
	| string
	| {name: string; text: string}
)>;

type SourceFiles = ReadonlyArray<{name: string; text: string}>;

type ParsedTestFiles = {
	globs: readonly string[];
	sourceFiles?: SourceFiles;
};

interface Context {
	cwd: string;
	pkg: PackageJsonWithTsdConfig;
	typingsFile: string;
	testFiles: ParsedTestFiles;
	config: Config;
}

interface Options {
	cwd: string;
	typingsFile?: string;
	testFiles?: TestFiles;
}
```

---

Still some items to finish, but opening this PR to get feedback:

- [ ] Document feature in readme and CLI help
- [ ] Add documentation comments to added functions/types
- [ ] Improve names/concepts (e.g. `globs` vs. `sourceFiles`, etc.)
- [ ] Consolidate repetition of some types