### PR TITLE
fix: don't log stacktrace if cli succeeds (regression)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"eslint-config-xo-typescript": "^0.41.1",
 		"execa": "^5.0.0",
 		"react": "^16.9.0",
+		"resolve-from": "^5.0.0",
 		"rxjs": "^6.5.3",
 		"typescript": "~4.9.5"
 	},

--- a/source/cli.ts
+++ b/source/cli.ts
@@ -54,14 +54,17 @@ const cli = meow(`
 		const diagnostics = await tsd(options);
 
 		if (diagnostics.length > 0) {
-			throw new Error(formatter(diagnostics, showDiff));
+			throw new Error(formatter(diagnostics, showDiff), {cause: 'tsd found diagnostics'});
 		}
 	} catch (error: unknown) {
 		const potentialError = error as Error | undefined;
-		const errorMessage = potentialError?.stack ?? potentialError?.message;
 
-		if (errorMessage) {
-			console.error(`Error running tsd: ${errorMessage}`);
+		if (potentialError?.cause === 'tsd found diagnostics') {
+			if (potentialError?.message) {
+				console.error(potentialError?.message);
+			}
+		} else if (potentialError?.stack) {
+			console.error(`Error running tsd: ${potentialError?.stack}`);
 		}
 
 		process.exit(1);

--- a/source/cli.ts
+++ b/source/cli.ts
@@ -64,7 +64,7 @@ const cli = meow(`
 				console.error(potentialError?.message);
 			}
 		} else if (potentialError?.stack) {
-			console.error(`Error running tsd: ${potentialError?.stack}`);
+			console.error(`Error running tsd:\n${potentialError?.stack}`);
 		}
 
 		process.exit(1);

--- a/source/cli.ts
+++ b/source/cli.ts
@@ -45,6 +45,7 @@ const cli = meow(`
 });
 
 (async () => {
+	let success = false;
 	try {
 		const cwd = cli.input.length > 0 ? cli.input[0] : process.cwd();
 		const {typings: typingsFile, files: testFiles, showDiff} = cli.flags;
@@ -54,15 +55,14 @@ const cli = meow(`
 		const diagnostics = await tsd(options);
 
 		if (diagnostics.length > 0) {
-			throw new Error(formatter(diagnostics, showDiff), {cause: 'tsd found diagnostics'});
+			success = true;
+			throw new Error(formatter(diagnostics, showDiff));
 		}
 	} catch (error: unknown) {
 		const potentialError = error as Error | undefined;
 
-		if (potentialError?.cause === 'tsd found diagnostics') {
-			if (potentialError?.message) {
-				console.error(potentialError?.message);
-			}
+		if (success && potentialError?.message) {
+			console.error(potentialError?.message);
 		} else if (potentialError?.stack) {
 			console.error(`Error running tsd:\n${potentialError?.stack}`);
 		}

--- a/source/cli.ts
+++ b/source/cli.ts
@@ -44,29 +44,39 @@ const cli = meow(`
 	},
 });
 
+/**
+ * Displays a message and exits, conditionally erroring.
+ *
+ * @param message The message to display.
+ * @param isError Whether or not to fail on exit.
+ */
+const exit = (message: string, {isError = true}: {isError?: boolean} = {}) => {
+	if (isError) {
+		console.error(message);
+		process.exit(1);
+	} else {
+		console.log(message);
+		process.exit(0);
+	}
+};
+
 (async () => {
-	let success = false;
 	try {
 		const cwd = cli.input.length > 0 ? cli.input[0] : process.cwd();
 		const {typings: typingsFile, files: testFiles, showDiff} = cli.flags;
 
-		const options = {cwd, typingsFile, testFiles};
-
-		const diagnostics = await tsd(options);
+		const diagnostics = await tsd({cwd, typingsFile, testFiles});
 
 		if (diagnostics.length > 0) {
-			success = true;
-			throw new Error(formatter(diagnostics, showDiff));
+			const hasErrors = diagnostics.some(diagnostic => diagnostic.severity === 'error');
+			const formattedDiagnostics = formatter(diagnostics, showDiff);
+
+			exit(formattedDiagnostics, {isError: hasErrors});
 		}
 	} catch (error: unknown) {
 		const potentialError = error as Error | undefined;
+		const errorMessage = potentialError?.stack ?? potentialError?.message ?? 'tsd unexpectedly crashed.';
 
-		if (success && potentialError?.message) {
-			console.error(potentialError?.message);
-		} else if (potentialError?.stack) {
-			console.error(`Error running tsd:\n${potentialError?.stack}`);
-		}
-
-		process.exit(1);
+		exit(`Error running tsd:\n${errorMessage}`);
 	}
 })();

--- a/source/test/cli.ts
+++ b/source/test/cli.ts
@@ -127,13 +127,15 @@ test('tsd logs stacktrace on failure', async t => {
 		cwd: path.join(__dirname, 'fixtures/empty-package-json')
 	}));
 
-	t.is(exitCode, 1);
+	const nodeModulesPath = path.resolve('node_modules');
 
+	t.is(exitCode, 1);
 	verifyCli(t, stderr, [
 		'Error running tsd:',
 		'JSONError: Unexpected end of JSON input while parsing empty string',
-		// TODO: check that stack matches without checking for exact filepath
-		// would have to match in CI and locally
+		`at parseJson (${nodeModulesPath}/parse-json/index.js:29:21)`,
+		`at module.exports (${nodeModulesPath}/read-pkg/index.js:17:15)`,
+		`at async module.exports (${nodeModulesPath}/read-pkg-up/index.js:14:16)`,
 	], {startLine: 0});
 });
 
@@ -153,5 +155,9 @@ test('exported formatter matches cli results', async t => {
 	const tsdResults = await tsd(options);
 	const formattedResults = formatter(tsdResults);
 
-	t.true(formattedResults.includes('✖  5:19  Argument of type number is not assignable to parameter of type string.'));
+	verifyCli(t, formattedResults, [
+		'✖  5:19  Argument of type number is not assignable to parameter of type string.',
+		'',
+		'1 error',
+	]);
 });

--- a/source/test/cli.ts
+++ b/source/test/cli.ts
@@ -132,9 +132,8 @@ test('tsd logs stacktrace on failure', async t => {
 	verifyCli(t, stderr, [
 		'Error running tsd:',
 		'JSONError: Unexpected end of JSON input while parsing empty string',
-		'at parseJson (/Users/tommymitchell/src/_open-source/tsd/node_modules/parse-json/index.js:29:21)',
-		'at module.exports (/Users/tommymitchell/src/_open-source/tsd/node_modules/read-pkg/index.js:17:15)',
-		'at async module.exports (/Users/tommymitchell/src/_open-source/tsd/node_modules/read-pkg-up/index.js:14:16)',
+		// TODO: check that stack matches without checking for exact filepath
+		// would have to match in CI and locally
 	], {startLine: 0});
 });
 

--- a/source/test/cli.ts
+++ b/source/test/cli.ts
@@ -4,6 +4,7 @@ import execa from 'execa';
 import readPkgUp from 'read-pkg-up';
 import tsd, {formatter} from '..';
 import {verifyCli} from './fixtures/utils';
+import resolveFrom from 'resolve-from';
 
 interface ExecaError extends Error {
 	readonly exitCode: number;
@@ -128,12 +129,13 @@ test('tsd logs stacktrace on failure', async t => {
 	}));
 
 	const nodeModulesPath = path.resolve('node_modules');
+	const parseJsonPath = resolveFrom.silent(`${nodeModulesPath}/read-pkg`, 'parse-json') ?? `${nodeModulesPath}/index.js`;
 
 	t.is(exitCode, 1);
 	verifyCli(t, stderr, [
 		'Error running tsd:',
 		'JSONError: Unexpected end of JSON input while parsing empty string',
-		`at parseJson (${nodeModulesPath}/parse-json/index.js:29:21)`,
+		`at parseJson (${parseJsonPath}:29:21)`,
 		`at module.exports (${nodeModulesPath}/read-pkg/index.js:17:15)`,
 		`at async module.exports (${nodeModulesPath}/read-pkg-up/index.js:14:16)`,
 	], {startLine: 0});

--- a/source/test/diff.ts
+++ b/source/test/diff.ts
@@ -1,4 +1,4 @@
-import {verifyWithDiff} from './fixtures/utils';
+import {verifyWithDiff, verifyCli} from './fixtures/utils';
 import execa, {ExecaError} from 'execa';
 import path from 'path';
 import test from 'ava';
@@ -41,8 +41,7 @@ test('diff cli', async t => {
 	const {exitCode, stderr} = await t.throwsAsync<ExecaError>(execa('dist/cli.js', [file, '--show-diff']));
 
 	t.is(exitCode, 1);
-
-	const expectedLines = [
+	verifyCli(t, stderr, [
 		'✖   8:0  Parameter type { life?: number | undefined; } is declared too wide for argument type { life: number; }.',
 		'',
 		'- { life?: number | undefined; }',
@@ -69,13 +68,5 @@ test('diff cli', async t => {
 		'+ This is a comment.',
 		'',
 		'6 errors'
-	];
-
-	// NOTE: If lines are added to the output in the future startLine and endLine should be adjusted.
-	const startLine = 2; // Skip tsd error message and file location.
-	const endLine = startLine + expectedLines.length; // Grab diff output only and skip stack trace.
-
-	const receivedLines = stderr.trim().split('\n').slice(startLine, endLine).map(line => line.trim());
-
-	t.deepEqual(receivedLines, expectedLines);
+	]);
 });

--- a/source/test/fixtures/utils.ts
+++ b/source/test/fixtures/utils.ts
@@ -132,10 +132,7 @@ export const verifyCli = (
 	expectedLines: string[],
 	{startLine}: {startLine: number} = {startLine: 1} // Skip file location.
 ) => {
-	// NOTE: If lines are added to the output in the future `startLine` and `endLine` should be adjusted.
-	const endLine = startLine + expectedLines.length; // Grab diff output only and skip stack trace.
-
-	const receivedLines = diagnostics.trim().split('\n').slice(startLine, endLine).map(line => line.trim());
+	const receivedLines = diagnostics.trim().split('\n').slice(startLine).map(line => line.trim());
 
 	t.deepEqual(receivedLines, expectedLines, 'Received diagnostics that are different from expectations!');
 };

--- a/source/test/fixtures/utils.ts
+++ b/source/test/fixtures/utils.ts
@@ -94,7 +94,7 @@ export const verifyWithFileName = (
  * @param diagnostics - List of diagnostics to verify.
  * @param expectations - Expected diagnostics.
  */
- export const verifyWithDiff = (
+export const verifyWithDiff = (
 	t: ExecutionContext,
 	diagnostics: Diagnostic[],
 	expectations: ExpectationWithDiff[]
@@ -116,4 +116,26 @@ export const verifyWithFileName = (
 	}));
 
 	t.deepEqual(diagnosticObjs, expectationObjs, 'Received diagnostics that are different from expectations!');
+};
+
+/**
+ * Verify a list of diagnostics reported from the CLI.
+ *
+ * @param t - The AVA execution context.
+ * @param diagnostics - List of diagnostics to verify.
+ * @param expectations - Expected diagnostics.
+ * @param startLine - Optionally specify how many lines to skip from start.
+ */
+export const verifyCli = (
+	t: ExecutionContext,
+	diagnostics: string,
+	expectedLines: string[],
+	{startLine}: {startLine: number} = {startLine: 1} // Skip file location.
+) => {
+	// NOTE: If lines are added to the output in the future `startLine` and `endLine` should be adjusted.
+	const endLine = startLine + expectedLines.length; // Grab diff output only and skip stack trace.
+
+	const receivedLines = diagnostics.trim().split('\n').slice(startLine, endLine).map(line => line.trim());
+
+	t.deepEqual(receivedLines, expectedLines, 'Received diagnostics that are different from expectations!');
 };


### PR DESCRIPTION
Starting in `v0.26.1`, successful runs of the CLI (i.e. when it doesn't crash) incorrectly report an error and error stack while running `tsd`:

```
Error running tsd: Error: 
  index.test-d.ts:26:0
  ✖  25:0  Expected an error, but found none.  
  ✖  26:0  ) expected.                         

  2 errors

    at ~/node_modules/tsd/dist/cli.js:64:19
    at Generator.next (<anonymous>)
    at fulfilled (~/node_modules/tsd/dist/cli.js:6:58)

```

This PR restores the old behavior and makes sure that the error message and stack are only displayed when `tsd` crashes.