### PR TITLE
Make `tsd` ignore unused locals by default

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -218,9 +218,11 @@ By default, `tsd` applies the following configuration:
 		"dom.iterable"
 	],
 	"module": "commonjs",
-	// The following option is set and is not overridable.
-	// It is set to `nodenext` if `module` is `nodenext`, `node16` if `module` is `node16` or `node` otherwise.
-	"moduleResolution": "node" | "node16" | "nodenext"
+	"esModuleInterop": true,
+	// The following options are set and are not overridable.
+	// Set to `nodenext` if `module` is `nodenext`, `node16` if `module` is `node16` or `node` otherwise.
+	"moduleResolution": "node" | "node16" | "nodenext",
+	"skipLibCheck": false
 }
 ```
 
@@ -237,7 +239,7 @@ These options will be overridden if a `tsconfig.json` file is found in your proj
 }
 ```
 
-*Default options will apply if you don't override them explicitly.* You can't override the `moduleResolution` option.
+*Default options will apply if you don't override them explicitly. You can't override the `moduleResolution` or `skipLibCheck` options.*
 
 ### Via the CLI
 

--- a/readme.md
+++ b/readme.md
@@ -219,6 +219,7 @@ By default, `tsd` applies the following configuration:
 	],
 	"module": "commonjs",
 	"esModuleInterop": true,
+	"noUnusedLocals": false,
 	// The following options are set and are not overridable.
 	// Set to `nodenext` if `module` is `nodenext`, `node16` if `module` is `node16` or `node` otherwise.
 	"moduleResolution": "node" | "node16" | "nodenext",

--- a/source/lib/config.ts
+++ b/source/lib/config.ts
@@ -44,6 +44,7 @@ export default (pkg: PackageJsonWithTsdConfig, cwd: string): Config => {
 			module,
 			target: ScriptTarget.ES2020,
 			esModuleInterop: true,
+			noUnusedLocals: false,
 			...combinedCompilerOptions,
 			moduleResolution: module === ModuleKind.NodeNext ?
 				ModuleResolutionKind.NodeNext :


### PR DESCRIPTION
Sets `tsconfig` option `noUnusedLocals: false` by default. Based on https://github.com/sindresorhus/type-fest/pull/560#discussion_r1133009963

Also documents further defaults in the readme.