### PR TITLE
Move to ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"@types/react": "^16.9.2",
 		"@typescript-eslint/eslint-plugin": "^4.26.0",
 		"@typescript-eslint/parser": "^4.26.0",
-		"ava": "^3.8.2",
+		"ava": "^5.2.0",
 		"cpy-cli": "^3.0.0",
 		"del-cli": "^3.0.0",
 		"eslint": "^7.27.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"email": "sam.verschueren@gmail.com",
 		"url": "https://github.com/SamVerschueren"
 	},
+	"type": "module",
 	"exports": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"bin": "./dist/cli.js",
@@ -17,10 +18,8 @@
 	},
 	"scripts": {
 		"prepublishOnly": "npm run build",
-		"pretest": "npm run build && cpy \"./**/**\" \"../../../dist/test/fixtures/\" --parents --cwd=source/test/fixtures",
 		"test": "npm run lint && ava",
-		"build": "npm run clean && tsc --project tsconfig.tsd.json && chmod +x dist/cli.js",
-		"clean": "del-cli dist",
+		"build": "del-cli dist && tsc --project tsconfig.tsd.json && chmod +x dist/cli.js",
 		"lint": "eslint \"source/**/*\"",
 		"lint:fix": "eslint --fix \"source/**/*\""
 	},
@@ -48,7 +47,6 @@
 		"read-pkg-up": "^7.0.0"
 	},
 	"devDependencies": {
-		"@ava/typescript": "^1.1.1",
 		"@types/node": "^14.18.21",
 		"@types/react": "^16.9.2",
 		"@typescript-eslint/eslint-plugin": "^4.26.0",
@@ -62,6 +60,7 @@
 		"execa": "^5.0.0",
 		"react": "^16.9.0",
 		"rxjs": "^6.5.3",
+		"tsx": "^3.12.5",
 		"typescript": "~4.9.5"
 	},
 	"ava": {
@@ -70,10 +69,11 @@
 			"source/test/**/*",
 			"!source/test/fixtures/**/*"
 		],
-		"typescript": {
-			"rewritePaths": {
-				"source/": "dist/"
-			}
-		}
+		"extensions": {
+			"ts": "module"
+		},
+		"nodeArguments": [
+			"--loader=tsx"
+		]
 	}
 }

--- a/source/cli.ts
+++ b/source/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import meow from 'meow';
-import formatter from './lib/formatter';
-import tsd from './lib';
+import formatter from './lib/formatter.js';
+import tsd from './lib/index.js';
 
 const cli = meow(`
 	Usage

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,6 +1,6 @@
-import tsd from './lib';
-import formatter from './lib/formatter';
+import tsd from './lib/index.js';
+import formatter from './lib/formatter.js';
 
-export * from './lib/assertions/assert';
+export * from './lib/assertions/assert.js';
 export {formatter};
 export default tsd;

--- a/source/lib/assertions/handlers/assignability.ts
+++ b/source/lib/assertions/handlers/assignability.ts
@@ -1,6 +1,6 @@
 import {CallExpression, TypeChecker} from '@tsd/typescript';
-import {Diagnostic} from '../../interfaces';
-import {makeDiagnosticWithDiff} from '../../utils';
+import {Diagnostic} from '../../interfaces.js';
+import {makeDiagnosticWithDiff} from '../../utils/index.js';
 
 /**
  * Asserts that the argument of the assertion is not assignable to the generic type of the assertion.

--- a/source/lib/assertions/handlers/expect-deprecated.ts
+++ b/source/lib/assertions/handlers/expect-deprecated.ts
@@ -1,7 +1,7 @@
 import {JSDocTagInfo} from '@tsd/typescript';
-import {Diagnostic} from '../../interfaces';
-import {Handler} from './handler';
-import {makeDiagnostic, tsutils} from '../../utils';
+import {Diagnostic} from '../../interfaces.js';
+import {Handler} from './handler.js';
+import {makeDiagnostic, tsutils} from '../../utils/index.js';
 
 interface Options {
 	filter(tags: Map<string, JSDocTagInfo>): boolean;

--- a/source/lib/assertions/handlers/handler.ts
+++ b/source/lib/assertions/handlers/handler.ts
@@ -1,5 +1,5 @@
 import {CallExpression, TypeChecker} from '@tsd/typescript';
-import {Diagnostic} from '../../interfaces';
+import {Diagnostic} from '../../interfaces.js';
 
 /**
  * A handler is a method which accepts the TypeScript type checker together with a set of assertion nodes. The type checker

--- a/source/lib/assertions/handlers/identicality.ts
+++ b/source/lib/assertions/handlers/identicality.ts
@@ -1,6 +1,6 @@
 import {CallExpression, TypeChecker, TypeFlags} from '@tsd/typescript';
-import {Diagnostic} from '../../interfaces';
-import {makeDiagnostic, makeDiagnosticWithDiff} from '../../utils';
+import {Diagnostic} from '../../interfaces.js';
+import {makeDiagnostic, makeDiagnosticWithDiff} from '../../utils/index.js';
 
 /**
  * Asserts that the argument of the assertion is identical to the generic type of the assertion.

--- a/source/lib/assertions/handlers/index.ts
+++ b/source/lib/assertions/handlers/index.ts
@@ -1,7 +1,7 @@
-export {Handler} from './handler';
+export {Handler} from './handler.js';
 
 // Handlers
-export {isIdentical, isNotIdentical, isNever} from './identicality';
-export {isNotAssignable} from './assignability';
-export {expectDeprecated, expectNotDeprecated} from './expect-deprecated';
-export {printTypeWarning, expectDocCommentIncludes} from './informational';
+export {isIdentical, isNotIdentical, isNever} from './identicality.js';
+export {isNotAssignable} from './assignability.js';
+export {expectDeprecated, expectNotDeprecated} from './expect-deprecated.js';
+export {printTypeWarning, expectDocCommentIncludes} from './informational.js';

--- a/source/lib/assertions/handlers/informational.ts
+++ b/source/lib/assertions/handlers/informational.ts
@@ -1,6 +1,6 @@
 import {CallExpression, TypeChecker, TypeFormatFlags} from '@tsd/typescript';
-import {Diagnostic} from '../../interfaces';
-import {makeDiagnostic, makeDiagnosticWithDiff, tsutils} from '../../utils';
+import {Diagnostic} from '../../interfaces.js';
+import {makeDiagnostic, makeDiagnosticWithDiff, tsutils} from '../../utils/index.js';
 
 /**
  * Default formatting flags set by TS plus the {@link TypeFormatFlags.NoTruncation NoTruncation} flag.

--- a/source/lib/assertions/handlers/strict-assertion.ts
+++ b/source/lib/assertions/handlers/strict-assertion.ts
@@ -1,6 +1,6 @@
 import {CallExpression, TypeChecker} from '@tsd/typescript';
-import {Diagnostic} from '../../interfaces';
-import {makeDiagnostic} from '../../utils';
+import {Diagnostic} from '../../interfaces.js';
+import {makeDiagnostic} from '../../utils/index.js';
 
 /**
  * Performs strict type assertion between the argument if the assertion, and the generic type of the assertion.

--- a/source/lib/assertions/index.ts
+++ b/source/lib/assertions/index.ts
@@ -1,5 +1,5 @@
 import {CallExpression, TypeChecker} from '@tsd/typescript';
-import {Diagnostic} from '../interfaces';
+import {Diagnostic} from '../interfaces.js';
 import {
 	Handler,
 	isIdentical,
@@ -10,7 +10,7 @@ import {
 	isNever,
 	printTypeWarning,
 	expectDocCommentIncludes,
-} from './handlers';
+} from './handlers/index.js';
 
 export enum Assertion {
 	EXPECT_TYPE = 'expectType',

--- a/source/lib/compiler.ts
+++ b/source/lib/compiler.ts
@@ -3,9 +3,9 @@ import {
 	createProgram,
 	Diagnostic as TSDiagnostic
 } from '@tsd/typescript';
-import {ExpectedError, extractAssertions, parseErrorAssertionToLocation} from './parser';
-import {Diagnostic, DiagnosticCode, Context, Location} from './interfaces';
-import {handle} from './assertions';
+import {ExpectedError, extractAssertions, parseErrorAssertionToLocation} from './parser.js';
+import {Diagnostic, DiagnosticCode, Context, Location} from './interfaces.js';
+import {handle} from './assertions/index.js';
 
 // List of diagnostic codes that should be ignored in general
 const ignoredDiagnostics = new Set<number>([

--- a/source/lib/config.ts
+++ b/source/lib/config.ts
@@ -10,7 +10,7 @@ import {
 	parseJsonSourceFileConfigFileContent,
 	ModuleKind
 } from '@tsd/typescript';
-import {Config, PackageJsonWithTsdConfig, RawCompilerOptions} from './interfaces';
+import {Config, PackageJsonWithTsdConfig, RawCompilerOptions} from './interfaces.js';
 
 /**
  * Load the configuration settings.

--- a/source/lib/formatter.ts
+++ b/source/lib/formatter.ts
@@ -1,5 +1,5 @@
 import formatter from 'eslint-formatter-pretty';
-import {Diagnostic} from './interfaces';
+import {Diagnostic} from './interfaces.js';
 import {diffStringsUnified} from 'jest-diff';
 
 interface FileWithDiagnostics {

--- a/source/lib/index.ts
+++ b/source/lib/index.ts
@@ -2,10 +2,10 @@ import path from 'path';
 import readPkgUp from 'read-pkg-up';
 import pathExists from 'path-exists';
 import globby from 'globby';
-import {getDiagnostics as getTSDiagnostics} from './compiler';
-import loadConfig from './config';
-import getCustomDiagnostics from './rules';
-import {Context, Config, Diagnostic, PackageJsonWithTsdConfig} from './interfaces';
+import {getDiagnostics as getTSDiagnostics} from './compiler.js';
+import loadConfig from './config.js';
+import getCustomDiagnostics from './rules/index.js';
+import {Context, Config, Diagnostic, PackageJsonWithTsdConfig} from './interfaces.js';
 
 export interface Options {
 	cwd: string;

--- a/source/lib/parser.ts
+++ b/source/lib/parser.ts
@@ -1,6 +1,6 @@
 import {Program, Node, CallExpression, forEachChild, isCallExpression, isPropertyAccessExpression, SymbolFlags} from '@tsd/typescript';
-import {Assertion} from './assertions';
-import {Location, Diagnostic} from './interfaces';
+import {Assertion} from './assertions/index.js';
+import {Location, Diagnostic} from './interfaces.js';
 
 const assertionFnNames = new Set<string>(Object.values(Assertion));
 

--- a/source/lib/rules/files-property.ts
+++ b/source/lib/rules/files-property.ts
@@ -1,8 +1,8 @@
 import path from 'path';
 import fs from 'fs';
 import globby from 'globby';
-import {Context, Diagnostic} from '../interfaces';
-import {getJSONPropertyPosition} from '../utils';
+import {Context, Diagnostic} from '../interfaces.js';
+import {getJSONPropertyPosition} from '../utils/index.js';
 
 /**
  * Rule which enforces the typings file to be present in the `files` list in `package.json`.

--- a/source/lib/rules/index.ts
+++ b/source/lib/rules/index.ts
@@ -1,6 +1,6 @@
-import filesProperty from './files-property';
-import typesProperty from './types-property';
-import {Diagnostic, Context} from '../interfaces';
+import filesProperty from './files-property.js';
+import typesProperty from './types-property.js';
+import {Diagnostic, Context} from '../interfaces.js';
 
 type RuleFunction = (context: Context) => Diagnostic[];
 

--- a/source/lib/rules/types-property.ts
+++ b/source/lib/rules/types-property.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
-import {Context, Diagnostic} from '../interfaces';
-import {getJSONPropertyPosition} from '../utils';
+import {Context, Diagnostic} from '../interfaces.js';
+import {getJSONPropertyPosition} from '../utils/index.js';
 
 /**
  * Rule which enforces the use of a `types` property over a `typings` property.

--- a/source/lib/utils/index.ts
+++ b/source/lib/utils/index.ts
@@ -1,7 +1,7 @@
-import makeDiagnostic from './make-diagnostic';
-import makeDiagnosticWithDiff from './make-diagnostic-with-diff';
-import getJSONPropertyPosition from './get-json-property-position';
-import * as tsutils from './typescript';
+import makeDiagnostic from './make-diagnostic.js';
+import makeDiagnosticWithDiff from './make-diagnostic-with-diff.js';
+import getJSONPropertyPosition from './get-json-property-position.js';
+import * as tsutils from './typescript.js';
 
 export {
 	getJSONPropertyPosition,

--- a/source/lib/utils/make-diagnostic-with-diff.ts
+++ b/source/lib/utils/make-diagnostic-with-diff.ts
@@ -1,5 +1,5 @@
 import {Node, Type, TypeChecker, TypeFormatFlags} from '@tsd/typescript';
-import {Diagnostic} from '../interfaces';
+import {Diagnostic} from '../interfaces.js';
 
 interface DiagnosticWithDiffOptions {
 	checker: TypeChecker;

--- a/source/lib/utils/make-diagnostic.ts
+++ b/source/lib/utils/make-diagnostic.ts
@@ -1,5 +1,5 @@
 import {Node} from '@tsd/typescript';
-import {Diagnostic} from '../interfaces';
+import {Diagnostic} from '../interfaces.js';
 
 /**
  * Create a diagnostic from the given `node`, `message` and optional `severity`.

--- a/tsconfig.tsd.json
+++ b/tsconfig.tsd.json
@@ -1,12 +1,12 @@
 {
 	"compilerOptions": {
 		"outDir": "dist",
-		"target": "es6",
+		"target": "ES2020", // Node.js 14
 		"lib": [
-			"es2015"
+			"ES2020"
 		],
-		"module": "commonjs",
-		"moduleResolution": "node",
+		"module": "node16",
+		"moduleResolution": "node16",
 		"declaration": true,
 		"pretty": true,
 		"newLine": "lf",


### PR DESCRIPTION
Closes #183.

Checklist:

- [X] Update `tsconfig.tsd.json`
	* Set `module` to `node16`
	* Set `target` to `ES2020`
- [X] Update `package.json`
	* Add `"type": "module"`
	* Update to `AVA` v5.2.0, add [`tsx`](https://github.com/esbuild-kit/tsx) for transpilation
		- [ ] Do we need to add "type checking" command? https://github.com/esbuild-kit/tsx#does-it-do-type-checking
	* Inline `clean` script
- [X] Add `.js` to relative imports in source
	* Is this needed for barrel imports as well? E.g:
		```ts
		import tsd from './lib';
		// vs
		import tsd from './lib/index.js';
		```
- [ ] Add `.js` to relative imports in test
	* Is this necessary either? I believe `tsx` supports "Node"-style imports within ESM.
	* Related, with `tsx` should `execa` expect `cli.js` or `cli.ts`?
- [ ] Make sure that Node builtins use the `node:` protocol

Speaking of tests, trying to run `AVA` causes errors with `@tsd/typescript`:

```sh
npx ava source/test/test.ts

(node:69218) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
  Uncaught exception in source/test/test.ts

  SyntaxError: The requested module '@tsd/typescript' does not provide an export named 'TypeFormatFlags'

  ✘ source/test/test.ts exited with a non-zero exit code: 1
  ─

  1 uncaught exception
```

In addition, updating `AVA` means that `t.throwsAsync` can also return `undefined`:

```ts
test('failure', async t => {
	const cwd = path.join(__dirname, 'fixtures/failure');
	const {exitCode} = await t.throwsAsync<ExecaError>(execa('../../../cli.js', {cwd}));
	//=> Property 'exitCode' does not exist on type 'ExecaError | undefined'.

	t.is(exitCode, 1);
});
```

---

cc: @sindresorhus 