### PR TITLE
fix(`formatter`): make export simpler

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -1,6 +1,5 @@
 import tsd from './lib';
-import formatter from './lib/formatter';
 
 export * from './lib/assertions/assert';
-export {formatter};
+export {default as formatter} from './lib/formatter';
 export default tsd;


### PR DESCRIPTION
Changes formatter export from

```ts
import formatter from './lib/formatter';
export {formatter};
```

to

```ts
export {default as formatter} from './lib/formatter';
```